### PR TITLE
Content update submission confirm

### DIFF
--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
@@ -23,12 +23,13 @@ outputHeaderStyles: true
     
     <p>You can review and download this report. You'll need to sign in and go to Your client to download it as a PDF.</p>
     
-    <p>Sign into the deputy service: <a href="{{ link }}">{{ link }}</a>
+    <p>Sign into the deputy service:<br/> 
+        <a href="{{ link }}">{{ link }}</a>
     </p>
 
-    <p>If you'd like to you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
+    <p>If you're ready you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
 
-    <p>Sign into the deputy service to start your next report<br/>
+    <p>Sign into the deputy service to start your next report:<br/>
       <a href="{{ link }}">{{ link }}</a>
     </p>
 

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
@@ -17,19 +17,22 @@ outputHeaderStyles: true
 
 
     {% block emailHTMLMessage %}
-        <p>Thank you for submitting your report for {{ submittedReport.startDate | date("d/m/Y") }} to {{ submittedReport.endDate | date("d/m/Y") }}.</p>
+    <p>Thank you for submitting your report for {{ submittedReport.startDate | date("d/m/Y") }} to {{ submittedReport.endDate | date("d/m/Y") }}.</p>
 
-        <br/>
-        <p>The Office of the Public Guardian (OPG) are in the process of reviewing your report and we will contact you once this has been done. </p>
+    <p>The Office of the Public Guardian (OPG) are in the process of reviewing your report and we will contact you once this has been done. </p>
+    
+    <p>You can review and download this report. You'll need to sign in and go to Your client to download it as a PDF.</p>
+    
+    <p>Sign into the deputy service: <a href="{{ link }}">{{ link }}</a>
+    </p>
 
-        <br/>
-        <p>There's a new deputy report for you to fill in, covering {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}.</p>
+    <p>If if you'd like to you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
 
-        <br/>
+    <p>Sign into the deputy service to start your next report<br/>
+      <a href="{{ link }}">{{ link }}</a>
+    </p>
 
-        <p>Sign into the deputy service to fill in your report <br/>
-          <a href="{{ link }}">{{ link }}</a>
-        </p>
+<p>Don't worry if you're not ready; we'll remind you when it's time to get started.</p>
 
         <br/>
          

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
@@ -26,7 +26,7 @@ outputHeaderStyles: true
     <p>Sign into the deputy service: <a href="{{ link }}">{{ link }}</a>
     </p>
 
-    <p>If if you'd like to you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
+    <p>If you'd like to you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
 
     <p>Sign into the deputy service to start your next report<br/>
       <a href="{{ link }}">{{ link }}</a>

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
@@ -27,7 +27,7 @@ outputHeaderStyles: true
         <a href="{{ link }}">{{ link }}</a>
     </p>
 
-    <p>If you're ready you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
+    <p>If you're ready, you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}. </p>
 
     <p>Sign into the deputy service to start your next report:<br/>
       <a href="{{ link }}">{{ link }}</a>

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.text.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.text.twig
@@ -7,7 +7,7 @@ You can review and download this report. You'll need to sign in and go to Your c
 Sign into the deputy service: 
 {{ link }}
 
-If you'd like to you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}.
+If you're ready, you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}.
 
 Sign into the deputy service to start your next report:
 {{ link }}

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.text.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.text.twig
@@ -2,10 +2,17 @@ Thank you for submitting your report for {{ submittedReport.startDate | date("d/
 
 The Office of the Public Guardian (OPG) are in the process of reviewing your report and we will contact you once this has been done.
 
-There's a new deputy report for you to fill in, covering {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}.
+You can review and download this report. You'll need to sign in and go to Your client to download it as a PDF.
 
-Sign into the deputy service to fill in your report
+Sign into the deputy service: 
 {{ link }}
+
+If you'd like to you can start your report for {{ newReport.startDate | date("d/m/Y") }} to {{ newReport.endDate | date("d/m/Y") }}.
+
+Sign into the deputy service to start your next report:
+{{ link }}
+
+Don't worry if you're not ready; we'll remind you when it's time to get started.
 
 
 Office of the Public Guardian


### PR DESCRIPTION
Update email content so users understand they can download and review this report, and that they don't have to make an immediate start on the next report.