### PR TITLE
Failsafe on ODR variable

### DIFF
--- a/docker/confd/templates/parameters.yml.tmpl
+++ b/docker/confd/templates/parameters.yml.tmpl
@@ -23,7 +23,11 @@ parameters:
             password: {{ getv (printf "/fixtures/%s/password" .) }}
             roleId: {{ getv (printf "/fixtures/%s/roleid" .) }}
             activated: {{ getv (printf "/fixtures/%s/activated" .) }}
+{{ if exists (printf "/fixtures/%s/odr" .) }}
             odrEnabled: {{ getv (printf "/fixtures/%s/odr" .) }}
+{{ else }}
+            odrEnabled: false
+{{ end }}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
If the ODR value is not defined we will default to false
