### PR TITLE
Update resetdb.sh

### DIFF
--- a/scripts/resetdb.sh
+++ b/scripts/resetdb.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -e
-#let's configure environment
-run-parts /etc/my_init.d
 
 cd /app
 export PGPASSWORD=$API_DATABASE_PASSWORD


### PR DESCRIPTION
@brettminnie just noticed that resetdb.sh was calling init scripts. That explains why a failing migrations was not solved by running this script