### PR TITLE
OPGOPS-1836: update docker php-fpm to 0.1.213

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opguk/php-fpm:0.1.209
+FROM registry.service.opg.digital/opguk/php-fpm:0.1.213
 
 RUN  apt-get update && apt-get install -y \
      php-pear php5-curl php5-memcached php5-redis php5-pgsql \


### PR DESCRIPTION
From: https://opgtransform.atlassian.net/browse/OPGOPS-1836