### PR TITLE
[DO NOT MERGE YET] DDPB-1280 do not change report type for submitted report on PA CSV up…

### DIFF
--- a/src/AppBundle/Service/PaService.php
+++ b/src/AppBundle/Service/PaService.php
@@ -270,7 +270,8 @@ class PaService
         $reportType = EntityDir\CasRec::getTypeBasedOnTypeofRepAndCorref($row['Typeofrep'], $row['Corref']);
         $report = $client->getReportByDueDate($reportEndDate);
         if ($report) {
-            if ($report->getType() != $reportType) {
+            // change report type if it's not already set AND report is not yet submitted
+            if ($report->getType() != $reportType && !$report->getSubmitted()) {
                 $this->log('Changing report type');
                 $report->setType($reportType);
                 $this->em->persist($report);


### PR DESCRIPTION
@iterative-it @slizzio to keep you in the loop. Report type should not be changed after the report has been submitted. Ticket is not in the sprint yet, so too early to merge this. Also I want to see the other implication of this. The report type change is not that easy as expected, as new year report should technically look at the CSV type from the CSV file, not from the previous report