### PR TITLE
DDPB-750 bank account name

### DIFF
--- a/src/AppBundle/Controller/Odr/AccountController.php
+++ b/src/AppBundle/Controller/Odr/AccountController.php
@@ -96,16 +96,24 @@ class AccountController extends RestController
 
     private function fillAccountData(EntityDir\Odr\BankAccount $account, array $data)
     {
-        if (array_key_exists('bank', $data) && $account->requiresBankName()) {
-            $account->setBank($data['bank']);
-        }
-
         if (array_key_exists('account_type', $data)) {
             $account->setAccountType($data['account_type']);
         }
 
-        if (array_key_exists('sort_code', $data) && $account->requiresSortCode()) {
-            $account->setSortCode($data['sort_code']);
+        if ($account->requiresBankName()) {
+            if (array_key_exists('bank', $data)) {
+                $account->setBank($data['bank']);
+            }
+        } else {
+            $account->setBank(null);
+        }
+
+        if ($account->requiresSortCode()) {
+            if (array_key_exists('sort_code', $data)) {
+                $account->setSortCode($data['sort_code']);
+            }
+        } else {
+            $account->setSortCode(null);
         }
 
         if (array_key_exists('account_number', $data)) {

--- a/src/AppBundle/Controller/Odr/AccountController.php
+++ b/src/AppBundle/Controller/Odr/AccountController.php
@@ -96,7 +96,7 @@ class AccountController extends RestController
 
     private function fillAccountData(EntityDir\Odr\BankAccount $account, array $data)
     {
-        if (array_key_exists('bank', $data)) {
+        if (array_key_exists('bank', $data) && $account->requiresBankName()) {
             $account->setBank($data['bank']);
         }
 
@@ -104,13 +104,8 @@ class AccountController extends RestController
             $account->setAccountType($data['account_type']);
         }
 
-        if (array_key_exists('sort_code', $data)) {
+        if (array_key_exists('sort_code', $data) && $account->requiresSortCode()) {
             $account->setSortCode($data['sort_code']);
-        }
-
-        if (!$account->requiresBankNameAndSortCode()) {
-            $account->setBank(null);
-            $account->setSortCode(null);
         }
 
         if (array_key_exists('account_number', $data)) {

--- a/src/AppBundle/Controller/Report/AccountController.php
+++ b/src/AppBundle/Controller/Report/AccountController.php
@@ -100,16 +100,24 @@ class AccountController extends RestController
     private function fillAccountData(EntityDir\Report\BankAccount $account, array $data)
     {
         //basicdata
-        if (array_key_exists('bank', $data) && $account->requiresBankName()) {
-            $account->setBank($data['bank']);
-        }
-
         if (array_key_exists('account_type', $data)) {
             $account->setAccountType($data['account_type']);
         }
 
-        if (array_key_exists('sort_code', $data) && $account->requiresSortCode()) {
-            $account->setSortCode($data['sort_code']);
+        if ($account->requiresBankName()) {
+            if (array_key_exists('bank', $data)) {
+                $account->setBank($data['bank']);
+            }
+        } else {
+            $account->setBank(null);
+        }
+
+        if ($account->requiresSortCode()) {
+            if (array_key_exists('sort_code', $data)) {
+                $account->setSortCode($data['sort_code']);
+            }
+        } else {
+            $account->setSortCode(null);
         }
 
         if (array_key_exists('account_number', $data)) {

--- a/src/AppBundle/Controller/Report/AccountController.php
+++ b/src/AppBundle/Controller/Report/AccountController.php
@@ -100,7 +100,7 @@ class AccountController extends RestController
     private function fillAccountData(EntityDir\Report\BankAccount $account, array $data)
     {
         //basicdata
-        if (array_key_exists('bank', $data)) {
+        if (array_key_exists('bank', $data) && $account->requiresBankName()) {
             $account->setBank($data['bank']);
         }
 
@@ -108,13 +108,8 @@ class AccountController extends RestController
             $account->setAccountType($data['account_type']);
         }
 
-        if (array_key_exists('sort_code', $data)) {
+        if (array_key_exists('sort_code', $data) && $account->requiresSortCode()) {
             $account->setSortCode($data['sort_code']);
-        }
-
-        if (!$account->requiresBankNameAndSortCode()) {
-            $account->setBank(null);
-            $account->setSortCode(null);
         }
 
         if (array_key_exists('account_number', $data)) {

--- a/src/AppBundle/Entity/Odr/BankAccount.php
+++ b/src/AppBundle/Entity/Odr/BankAccount.php
@@ -33,10 +33,20 @@ class BankAccount
      *
      * @JMS\Exclude
      */
-    private static $typesRequiringSortCode = [
+    private static $typesNotRequiringSortCode = [
         'postoffice',
         'cfo',
         'other_no_sortcode'
+    ];
+
+    /**
+     * Keep in sync with client.
+     *
+     * @JMS\Exclude
+     */
+    private static $typesNotRequiringBankName = [
+        'postoffice',
+        'cfo'
     ];
 
     /**
@@ -140,13 +150,23 @@ class BankAccount
     }
 
     /**
+     * Bank name required.
+     *
+     * @return boolean
+     */
+    public function requiresBankName()
+    {
+        return !in_array($this->getAccountType(), self::$typesNotRequiringBankName);
+    }
+
+    /**
      * Sort code required.
      *
-     * @return string
+     * @return boolean
      */
-    public function requiresBankNameAndSortCode()
+    public function requiresSortCode()
     {
-        return !in_array($this->getAccountType(), self::$typesRequiringSortCode);
+        return !in_array($this->getAccountType(), self::$typesNotRequiringSortCode);
     }
 
     public function getLastEdit()

--- a/src/AppBundle/Entity/Report/BankAccount.php
+++ b/src/AppBundle/Entity/Report/BankAccount.php
@@ -34,10 +34,20 @@ class BankAccount
      *
      * @JMS\Exclude
      */
-    private static $typesRequiringSortCode = [
+    private static $typesNotRequiringSortCode = [
         'postoffice',
         'cfo',
         'other_no_sortcode'
+    ];
+
+    /**
+     * Keep in sync with client.
+     *
+     * @JMS\Exclude
+     */
+    private static $typesNotRequiringBankName = [
+        'postoffice',
+        'cfo'
     ];
 
     /**
@@ -410,13 +420,23 @@ class BankAccount
     }
 
     /**
+     * Bank name required.
+     *
+     * @return boolean
+     */
+    public function requiresBankName()
+    {
+        return !in_array($this->getAccountType(), self::$typesNotRequiringBankName);
+    }
+
+    /**
      * Sort code required.
      *
-     * @return string
+     * @return boolean
      */
-    public function requiresBankNameAndSortCode()
+    public function requiresSortCode()
     {
-        return !in_array($this->getAccountType(), self::$typesRequiringSortCode);
+        return !in_array($this->getAccountType(), self::$typesNotRequiringSortCode);
     }
 
     public function getIsJointAccount()


### PR DESCRIPTION
There was an assumption that bank account types which didn't require a sort code ALSO didn't require a bank account name, but this is incorrect: the type 'other_no_sortcode' requires no sort code but still requires a bank name

SO work done to turn the requiresBankNameAndSortCode() function into separate requiresBankName() and requiresSortCode() functions