### PR TITLE
DDPB-1764 parallel install of composer deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY composer.lock /app/
 WORKDIR /app
 USER app
 ENV  HOME /app
-RUN  composer install --prefer-source --no-interaction --no-scripts
+RUN  composer global require hirak/prestissimo
+RUN  composer install --prefer-dist --no-interaction --no-scripts
 
 # install remaining parts of app
 ADD  . /app


### PR DESCRIPTION
same as of https://github.com/ministryofjustice/opg-digi-deps-client/pull/842

This PR aims to shrink the ```docker build . ``` times to negative values.
Not there yet, but locally I achieved some good results:

my baseline
On jenkins, the 01_Build_Docker_Images job averages around 30minutes

locally:

```
time docker build --no-cache .

real    9m10.764s
user    0m0.239s
sys     0m0.053s

```

with these changes:

```
time docker build --no-cache .

real    1m33.546s
user    0m0.230s
sys     0m0.049s
```

jenkins jobs:

(25 min) with these changes:
https://jenkins.service.opg.digital/job/Digi-Deps/job/01_Build_Docker_Images/659/console


(4 min) With these changes + https://github.com/ministryofjustice/opg-digi-deps-client/pull/842 + https://github.com/ministryofjustice/opg-digi-deps-docker/pull/60
https://jenkins.service.opg.digital/job/Digi-Deps/job/01_Build_Docker_Images/658/console


