### PR TITLE
DDPB-1764: split Dockerfile and add a nightly Dockerfile.base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,4 @@
-FROM registry.service.opg.digital/opguk/php-fpm
-
-RUN  apt-get update && apt-get install -y \
-     php-pear php5-curl php5-redis php5-pgsql \
-     dos2unix postgresql-client && \
-     apt-get clean && apt-get autoremove && \
-     rm -rf /var/lib/cache/* /var/lib/log/* /tmp/* /var/tmp/*
-
-RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
-
-# build app dependencies
-RUN  composer self-update
-COPY composer.json /app/
-COPY composer.lock /app/
-WORKDIR /app
-USER app
-ENV  HOME /app
-RUN  composer global require hirak/prestissimo
-RUN  composer install --prefer-dist --no-interaction --no-scripts
+FROM registry.service.opg.digital/opguk/digi-deps-api-base:nightly
 
 # install remaining parts of app
 ADD  . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM registry.service.opg.digital/opguk/digi-deps-api-base:nightly
 
+# build app dependencies
+COPY composer.json /app/
+COPY composer.lock /app/
+WORKDIR /app
+USER app
+ENV  HOME /app
+RUN  composer global require hirak/prestissimo
+RUN  composer install --prefer-dist --no-interaction --no-scripts
+
 # install remaining parts of app
 ADD  . /app
 USER root
@@ -28,3 +37,4 @@ ADD  docker/my_init.d /etc/my_init.d
 RUN  chmod a+x /etc/my_init.d/*
 
 ENV  OPG_SERVICE api
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM registry.service.opg.digital/opguk/digi-deps-api-base:nightly
 
 # build app dependencies
-COPY composer.json /app/
-COPY composer.lock /app/
 WORKDIR /app
 USER app
 ENV  HOME /app
-RUN  composer global require hirak/prestissimo
+COPY composer.json /app/
+COPY composer.lock /app/
 RUN  composer install --prefer-dist --no-interaction --no-scripts
 
 # install remaining parts of app

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,20 @@
+FROM registry.service.opg.digital/opguk/php-fpm
+
+RUN  apt-get update && apt-get install -y \
+     php-pear php5-curl php5-redis php5-pgsql \
+     dos2unix postgresql-client && \
+     apt-get clean && apt-get autoremove && \
+     rm -rf /var/lib/cache/* /var/lib/log/* /tmp/* /var/tmp/*
+
+RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+# build app dependencies
+RUN  composer self-update
+COPY composer.json /app/
+COPY composer.lock /app/
+WORKDIR /app
+USER app
+ENV  HOME /app
+RUN  composer global require hirak/prestissimo
+RUN  composer install --prefer-dist --no-interaction --no-scripts
+

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,11 +10,8 @@ RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.
 
 # build app dependencies
 RUN  composer self-update
-COPY composer.json /app/
-COPY composer.lock /app/
 WORKDIR /app
 USER app
 ENV  HOME /app
 RUN  composer global require hirak/prestissimo
-RUN  composer install --prefer-dist --no-interaction --no-scripts
 


### PR DESCRIPTION
See: https://github.com/ministryofjustice/opg-digi-deps-docker/pull/61

This PR splits the Dockerfile into a nightly build using a Dockerfile.base and the normal build which will consume a FROM: nnnnn-base:nightly.
