### PR TITLE
DDPB-2468 Remove Agreed costs option from 105

### DIFF
--- a/app/DoctrineMigrations/Version208.php
+++ b/app/DoctrineMigrations/Version208.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version208 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE report DROP prof_dc_hc_agreed');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE report ADD prof_dc_hc_agreed BOOLEAN DEFAULT NULL');
+    }
+}

--- a/src/AppBundle/Controller/Report/ReportController.php
+++ b/src/AppBundle/Controller/Report/ReportController.php
@@ -462,7 +462,6 @@ class ReportController extends RestController
         // update depending data depending on the selection on the "how charged" checkboxes
         if (array_key_exists('prof_deputy_costs_how_charged_fixed', $data)
             || array_key_exists('prof_deputy_costs_how_charged_assessed', $data)
-            || array_key_exists('prof_deputy_costs_how_charged_agreed', $data)
         ) {
             if ($report->hasProfDeputyCostsHowChargedFixedOnly()) {
                 $report->setProfDeputyCostsHasInterim(null);

--- a/src/AppBundle/Controller/Report/ReportController.php
+++ b/src/AppBundle/Controller/Report/ReportController.php
@@ -459,11 +459,6 @@ class ReportController extends RestController
             $report->updateSectionsStatusCache([Report::SECTION_PROF_DEPUTY_COSTS]);
         }
 
-        if (array_key_exists('prof_deputy_costs_how_charged_agreed', $data)) {
-            $report->setProfDeputyCostsHowChargedAgreed($data['prof_deputy_costs_how_charged_agreed']);
-            $report->updateSectionsStatusCache([Report::SECTION_PROF_DEPUTY_COSTS]);
-        }
-
         // update depending data depending on the selection on the "how charged" checkboxes
         if (array_key_exists('prof_deputy_costs_how_charged_fixed', $data)
             || array_key_exists('prof_deputy_costs_how_charged_assessed', $data)

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -27,14 +27,6 @@ trait ReportProfDeputyCostsTrait
     private $profDeputyCostsHowChargedAssessed;
 
     /**
-     * @JMS\Type("boolean")
-     * @JMS\Groups({"prof-deputy-costs-how-charged"})
-     * @ORM\Column(name="prof_dc_hc_agreed", type="boolean", nullable=true)
-     */
-    private $profDeputyCostsHowChargedAgreed;
-
-
-    /**
      * @var string yes/no
      *
      * @JMS\Type("string")
@@ -177,24 +169,6 @@ trait ReportProfDeputyCostsTrait
     public function setProfDeputyCostsHowChargedAssessed($profDeputyCostsHowChargedAssessed)
     {
         $this->profDeputyCostsHowChargedAssessed = $profDeputyCostsHowChargedAssessed;
-        return $this;
-    }
-
-    /**
-     * @return boolean
-     */
-    public function getProfDeputyCostsHowChargedAgreed()
-    {
-        return $this->profDeputyCostsHowChargedAgreed;
-    }
-
-    /**
-     * @param string $profDeputyCostsHowChargedAgreed
-     * @return ReportProfDeputyCostsTrait
-     */
-    public function setProfDeputyCostsHowChargedAgreed($profDeputyCostsHowChargedAgreed)
-    {
-        $this->profDeputyCostsHowChargedAgreed = $profDeputyCostsHowChargedAgreed;
         return $this;
     }
 
@@ -439,7 +413,6 @@ trait ReportProfDeputyCostsTrait
     public function hasProfDeputyCostsHowChargedFixedOnly()
     {
         return $this->profDeputyCostsHowChargedFixed
-            && !$this->profDeputyCostsHowChargedAssessed
-            && !$this->profDeputyCostsHowChargedAgreed;
+            && !$this->profDeputyCostsHowChargedAssessed;
     }
 }

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -358,7 +358,6 @@ trait ReportProfDeputyCostsTrait
 
         //TODO move to method
         $onlyFixedTicked = $this->getProfDeputyCostsHowChargedFixed()
-            && ! $this->getProfDeputyCostsHowChargedAgreed()
             && ! $this->getProfDeputyCostsHowChargedAssessed();
 
         // return null if data incomplete

--- a/src/AppBundle/Service/ReportStatusService.php
+++ b/src/AppBundle/Service/ReportStatusService.php
@@ -396,11 +396,9 @@ class ReportStatusService
 
         //TODO move to method
         $onlyFixedTicked = $this->report->getProfDeputyCostsHowChargedFixed()
-            && ! $this->report->getProfDeputyCostsHowChargedAgreed()
             && ! $this->report->getProfDeputyCostsHowChargedAssessed();
 
         $atLeastOneTicked = $this->report->getProfDeputyCostsHowChargedFixed()
-            || $this->report->getProfDeputyCostsHowChargedAgreed()
             || $this->report->getProfDeputyCostsHowChargedAssessed();
 
         if (!$atLeastOneTicked) {

--- a/tests/AppBundle/Service/ReportStatusServiceTest.php
+++ b/tests/AppBundle/Service/ReportStatusServiceTest.php
@@ -87,7 +87,6 @@ class ReportStatusServiceTest extends \PHPUnit_Framework_TestCase
                 'paFeesExpensesNotStarted'      => null,
                 'paFeesExpensesCompleted'       => null,
                 'getProfDeputyCostsHowChargedFixed' => null,
-                'getProfDeputyCostsHowChargedAgreed' => null,
                 'getProfDeputyCostsHowChargedAssessed' => null,
                 'getProfDeputyCostsHasPrevious' => null,
                 'getProfDeputyFixedCost' => null,
@@ -417,7 +416,7 @@ class ReportStatusServiceTest extends \PHPUnit_Framework_TestCase
     {
 
         $onlyFixedTicked = ['getProfDeputyCostsHowChargedFixed' => true];
-        $twoTicked = ['getProfDeputyCostsHowChargedFixed' => true, 'getProfDeputyCostsHowChargedAgreed' => true];
+        $twoTicked = ['getProfDeputyCostsHowChargedFixed' => true, 'getProfDeputyCostsHowChargedAssessed' => true];
 
         $prevNo = ['getProfDeputyCostsHasPrevious' => 'no'];
         $prevYes = ['getProfDeputyCostsHasPrevious' => 'yes', 'getProfDeputyPreviousCosts' => [1, 2]];


### PR DESCRIPTION
Removes `profDeputyCostsHowChargedAgreed` property from `ReportProfDeputyCostsTrait` and drops references to it in the API responses and tests.

The [client PR](https://github.com/ministryofjustice/opg-digi-deps-client/pull/1148) should be merged before this to ensure that the client isn't making reference to these fields once they're removed.