### PR TITLE
DDPB-2390 Fix unit tests with relative years

### DIFF
--- a/src/AppBundle/Entity/Client.php
+++ b/src/AppBundle/Entity/Client.php
@@ -897,8 +897,13 @@ class Client
      * @JMS\Groups({"checklist-information"})
      * @return \DateTime|null
      */
-    public function getExpectedReportStartDate()
+    public function getExpectedReportStartDate($year = NULL)
     {
+        // Default year to current
+        if (!isset($year)) {
+            $year = date('Y');
+        }
+
         // clone datetime object. Do not alter object courtDate property.
         /** @var \DateTime $expectedReportStartDate */
         if (!($this->getCourtDate() instanceof \DateTime)) {
@@ -913,12 +918,12 @@ class Client
         }
 
         // if court Date is this year, just return it as the start date
-        if ($expectedReportStartDate->format('Y') == date('Y')) {
+        if ($expectedReportStartDate->format('Y') == $year) {
             return $this->getCourtDate();
         }
 
         // else make it last year
-        $expectedReportStartDate->setDate(date('Y')-1, $expectedReportStartDate->format('m'), $expectedReportStartDate->format('d'));
+        $expectedReportStartDate->setDate($year-1, $expectedReportStartDate->format('m'), $expectedReportStartDate->format('d'));
 
         return $expectedReportStartDate;
     }
@@ -934,12 +939,12 @@ class Client
      *
      * @return \DateTime|null
      */
-    public function getExpectedReportEndDate()
+    public function getExpectedReportEndDate($year = NULL)
     {
-        if (!($this->getExpectedReportStartDate() instanceof \DateTime)) {
+        if (!($this->getExpectedReportStartDate($year) instanceof \DateTime)) {
             return null;
         }
-        $expectedReportEndDate = clone $this->getExpectedReportStartDate();
+        $expectedReportEndDate = clone $this->getExpectedReportStartDate($year);
         return $expectedReportEndDate->modify('+1year -1day');
     }
 

--- a/tests/AppBundle/Entity/ClientTest.php
+++ b/tests/AppBundle/Entity/ClientTest.php
@@ -52,6 +52,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2018-08-15'), 2019, new \DateTime('2018-08-15')],
             [new \DateTime('2018-08-16'), 2019, new \DateTime('2018-08-16')],
             [new \DateTime('2019-08-16'), 2019, new \DateTime('2019-08-16')],
+            [new \DateTime('2016-02-29'), 2020, new \DateTime('2019-03-01')],
+            [new \DateTime('2020-02-29'), 2020, new \DateTime('2020-02-29')],
+            [new \DateTime('2020-02-29'), 2021, new \DateTime('2020-02-29')],
+            [new \DateTime('2020-02-29'), 2022, new \DateTime('2021-03-01')],
         ];
     }
 
@@ -70,7 +74,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('1999-03-01'), 2016, new \DateTime('2016-02-29')],
             [new \DateTime('2018-08-15'), 2019, new \DateTime('2019-08-14')],
             [new \DateTime('2018-08-16'), 2019, new \DateTime('2019-08-15')],
-            [new \DateTime('2017-08-17'), 2019, new \DateTime('2019-08-16')]
+            [new \DateTime('2017-08-17'), 2019, new \DateTime('2019-08-16')],
         ];
     }
 

--- a/tests/AppBundle/Entity/ClientTest.php
+++ b/tests/AppBundle/Entity/ClientTest.php
@@ -41,18 +41,17 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function courtDateExpectedStartDateProvider()
     {
-        $currentYear = date('Y');
-
         return [
-            [new \DateTime('2000-01-01'), new \DateTime(($currentYear-1) . '-01-01')],
-            [new \DateTime('2000-12-31'), new \DateTime(($currentYear-1) . '-12-31')],
-            [new \DateTime('2003-09-30'), new \DateTime(($currentYear-1) . '-09-30')],
-            [new \DateTime('2015-03-31'), new \DateTime(($currentYear-1) . '-03-31')],
-            [new \DateTime('2016-02-29'), new \DateTime(($currentYear-1) . '-03-01')],
-            [new \DateTime('2017-03-01'), new \DateTime(($currentYear-1) . '-03-01')],
-            [new \DateTime('2018-08-15'), new \DateTime(($currentYear-1) . '-08-15')],
-            [new \DateTime('2018-08-16'), new \DateTime(($currentYear-1) . '-08-16')],
-            [new \DateTime('2019-08-16'), new \DateTime(($currentYear) . '-08-16')],
+            [new \DateTime('2000-01-01'), 2019, new \DateTime('2018-01-01')],
+            [new \DateTime('2000-12-31'), 2019, new \DateTime('2018-12-31')],
+            [new \DateTime('2003-09-30'), 2019, new \DateTime('2018-09-30')],
+            [new \DateTime('2015-03-31'), 2019, new \DateTime('2018-03-31')],
+            [new \DateTime('2016-02-29'), 2019, new \DateTime('2018-03-01')],
+            [new \DateTime('2012-02-29'), 2017, new \DateTime('2016-02-29')],
+            [new \DateTime('2017-03-01'), 2019, new \DateTime('2018-03-01')],
+            [new \DateTime('2018-08-15'), 2019, new \DateTime('2018-08-15')],
+            [new \DateTime('2018-08-16'), 2019, new \DateTime('2018-08-16')],
+            [new \DateTime('2019-08-16'), 2019, new \DateTime('2019-08-16')],
         ];
     }
 
@@ -61,42 +60,41 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function courtDateExpectedEndDateProvider()
     {
-        $currentYear = date('Y');
-
         return [
-            [new \DateTime('2000-01-01'), new \DateTime(($currentYear-1) . '-12-31')],
-            [new \DateTime('2000-12-31'), new \DateTime(($currentYear) . '-12-30')],
-            [new \DateTime('2003-09-30'), new \DateTime(($currentYear) . '-09-29')],
-            [new \DateTime('2015-03-31'), new \DateTime(($currentYear) . '-03-30')],
-            [new \DateTime('2016-02-29'), new \DateTime(($currentYear) . '-02-28')],
-            [new \DateTime('2017-03-01'), new \DateTime(($currentYear) . '-02-28')],
-            [new \DateTime('2018-08-15'), new \DateTime(($currentYear) . '-08-14')],
-            [new \DateTime('2018-08-16'), new \DateTime(($currentYear) . '-08-15')],
-            [new \DateTime('2017-08-17'), new \DateTime(($currentYear) . '-08-16')]
+            [new \DateTime('2000-01-01'), 2019, new \DateTime('2018-12-31')],
+            [new \DateTime('2000-12-31'), 2019, new \DateTime('2019-12-30')],
+            [new \DateTime('2003-09-30'), 2019, new \DateTime('2019-09-29')],
+            [new \DateTime('2015-03-31'), 2019, new \DateTime('2019-03-30')],
+            [new \DateTime('2016-02-29'), 2019, new \DateTime('2019-02-28')],
+            [new \DateTime('2017-03-01'), 2019, new \DateTime('2019-02-28')],
+            [new \DateTime('1999-03-01'), 2016, new \DateTime('2016-02-29')],
+            [new \DateTime('2018-08-15'), 2019, new \DateTime('2019-08-14')],
+            [new \DateTime('2018-08-16'), 2019, new \DateTime('2019-08-15')],
+            [new \DateTime('2017-08-17'), 2019, new \DateTime('2019-08-16')]
         ];
     }
 
     /**
      * @dataProvider courtDateExpectedStartDateProvider
      */
-    public function testGetExpectedStartDate($courtDate, $expected)
+    public function testGetExpectedStartDate($courtDate, $year, $expected)
     {
         $this->object->setCourtDate($courtDate);
         $this->assertEquals(
             $expected->format('d/m/Y'),
-            $this->object->getExpectedReportStartDate()->format('d/m/Y')
+            $this->object->getExpectedReportStartDate($year)->format('d/m/Y')
         );
     }
 
     /**
      * @dataProvider courtDateExpectedEndDateProvider
      */
-    public function testGetExpectedEndDate($courtDate, $expected)
+    public function testGetExpectedEndDate($courtDate, $year, $expected)
     {
         $this->object->setCourtDate($courtDate);
         $this->assertEquals(
             $expected->format('d/m/Y'),
-            $this->object->getExpectedReportEndDate()->format('d/m/Y')
+            $this->object->getExpectedReportEndDate($year)->format('d/m/Y')
         );
     }
 }


### PR DESCRIPTION
The `getExpectedReportStartDate` and `getExpectedReportEndDate` methods use `date('Y')` to calculate their output, meaning the tests are all relative to the current year. We want static test input and output.

Because `date()` is tightly integrated into the functions, we can't easily create static tests. To get around this, this PR adds an additional `$year` argument to the methods which is used in the calculations instead. This can be manually specified, but defaults to `date('Y')` so existing functionality isn't impeded.

The result allows for static unit tests, but adds the overhead of an additional function argument which is only used in testing.