### PR TITLE
 DDPB-2517: Allow more complex users in test fixtures

### DIFF
--- a/docker/confd/templates/parameters.yml.tmpl
+++ b/docker/confd/templates/parameters.yml.tmpl
@@ -21,6 +21,7 @@ parameters:
             lastname: {{ getv (printf "/fixtures/%s/lastname" .) }}
             password: {{ getv (printf "/fixtures/%s/password" .) }}
             {{ if exists (printf "/fixtures/%s/rolename" . ) }}roleName: {{ getv (printf "/fixtures/%s/rolename" .) }}{{ end }}
+            {{ if exists (printf "/fixtures/%s/teamname" . ) }}teamName: {{ getv (printf "/fixtures/%s/teamname" .) }}{{ end }}
             activated: {{ getv (printf "/fixtures/%s/activated" .) }}
             ndrEnabled: {{ getv (printf "/fixtures/%s/odr" .) }}
             {{ if exists (printf "/fixtures/%s/deputyno" . ) }}deputyNo: {{ getv (printf "/fixtures/%s/deputyno" .) }}{{ end }}

--- a/src/AppBundle/Command/AddSingleUserCommand.php
+++ b/src/AppBundle/Command/AddSingleUserCommand.php
@@ -160,8 +160,17 @@ class AddSingleUserCommand extends ContainerAwareCommand
         /**
          * Create report
          */
-        if (in_array($user->getRoleName(), [User::ROLE_PROF_NAMED, User::ROLE_PA_NAMED])) {
-            $type = CasRec::getTypeBasedOnTypeofRepAndCorref($data['typeOfReport'], $data['corref'], $user->getRoleName());
+        if (in_array($user->getRoleName(), [User::ROLE_PROF_NAMED, User::ROLE_PROF_ADMIN, User::ROLE_PA_NAMED, User::ROLE_PA_ADMIN])) {
+            if (in_array($user->getRoleName(), [User::ROLE_PROF_NAMED, User::ROLE_PA_NAMED])) {
+                $type = CasRec::getTypeBasedOnTypeofRepAndCorref($data['typeOfReport'], $data['corref'], $user->getRoleName());
+            } else if ($user->getRoleName() === User::ROLE_PROF_ADMIN) {
+                $type = $data['typeOfReport'] === 'OPG102' ? Report::TYPE_102_5 : Report::TYPE_103_5;
+            } else if ($user->getRoleName() === User::ROLE_PA_ADMIN) {
+                $type = $data['typeOfReport'] === 'OPG102' ? Report::TYPE_102_6 : Report::TYPE_103_6;
+            } else {
+                throw new \RuntimeException('Could not determine report type');
+            }
+
             $startDate = \DateTime::createFromFormat('d/m/Y', '01/11/2018');
             $endDate = \DateTime::createFromFormat('d/m/Y', '01/11/2019');
 

--- a/src/AppBundle/Command/AddSingleUserCommand.php
+++ b/src/AppBundle/Command/AddSingleUserCommand.php
@@ -176,8 +176,8 @@ class AddSingleUserCommand extends ContainerAwareCommand
                 throw new \RuntimeException('Could not determine report type');
             }
 
-            $startDate = \DateTime::createFromFormat('d/m/Y', '01/11/2018');
-            $endDate = \DateTime::createFromFormat('d/m/Y', '01/11/2019');
+            $startDate = $client->getExpectedReportStartDate();
+            $endDate = $client->getExpectedReportEndDate();
 
             $report = new Report($client, $type, $startDate, $endDate);
             $em->persist($report);

--- a/src/AppBundle/Command/AddSingleUserCommand.php
+++ b/src/AppBundle/Command/AddSingleUserCommand.php
@@ -65,6 +65,7 @@ class AddSingleUserCommand extends ContainerAwareCommand
         $em = $this->getContainer()->get('em'); /* @var $em \Doctrine\ORM\EntityManager */
         $userRepo = $em->getRepository('AppBundle\Entity\User');
         $teamRepo = $em->getRepository('AppBundle\Entity\Team');
+        $clientRepo = $em->getRepository('AppBundle\Entity\Client');
         $email = $data['email'];
 
         $output->write("User $email: ");
@@ -119,7 +120,7 @@ class AddSingleUserCommand extends ContainerAwareCommand
          * Deputy user::
          * Add CASREC entry + Client
          */
-        if (!in_array($data['roleName'], [User::ROLE_ADMIN, User::ROLE_AD, User::ROLE_CASE_MANAGER])) {
+        if (!in_array($data['roleName'], [User::ROLE_ADMIN, User::ROLE_AD, User::ROLE_CASE_MANAGER]) && isset($data['clientSurname'])) {
             $casRecEntity = $casRecEntity = new CasRec($this->extractDataToRow($data));
             $em->persist($casRecEntity);
 
@@ -140,6 +141,10 @@ class AddSingleUserCommand extends ContainerAwareCommand
                 $ndr = new Ndr($client);
                 $em->persist($ndr);
             }
+        } else if (isset($data['caseNumber'])) {
+            // If client already exists, just assign user
+            $client = $clientRepo->findOneBy(['caseNumber' => CasRec::normaliseCaseNumber($data['caseNumber'])]);
+            $user->addClient($client);
         }
 
         /**

--- a/src/AppBundle/Command/AddSingleUserCommand.php
+++ b/src/AppBundle/Command/AddSingleUserCommand.php
@@ -144,7 +144,9 @@ class AddSingleUserCommand extends ContainerAwareCommand
         } else if (isset($data['caseNumber'])) {
             // If client already exists, just assign user
             $client = $clientRepo->findOneBy(['caseNumber' => CasRec::normaliseCaseNumber($data['caseNumber'])]);
-            $user->addClient($client);
+            if ($client instanceof Client) {
+                $user->addClient($client);
+            }
         }
 
         /**

--- a/src/AppBundle/Command/FixturesCommand.php
+++ b/src/AppBundle/Command/FixturesCommand.php
@@ -26,7 +26,7 @@ class FixturesCommand extends AddSingleUserCommand
         // user and roles
         $fixtures = (array) $this->getContainer()->getParameter('fixtures');
         foreach ($fixtures as $email => $data) {
-            $this->addSingleUser($output, ['email' => $email] + $data, ['flush' => false]);
+            $this->addSingleUser($output, ['email' => $email] + $data, ['flush' => true]);
         }
         $em->flush();
     }

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -274,6 +274,6 @@ class ClientControllerTest extends AbstractTestController
             'AuthToken' => self::$tokenAdmin,
         ])['data'];
 
-        $this->assertCount(9, $data);
+        $this->assertCount(4, $data);
     }
 }


### PR DESCRIPTION
In DDPB-2517, we are adding new user accounts to test fixtures to allow testers to easily log in as professional and PA deputies.

Supporting these new deputy types requires some changes to the `AddSingleUserCommand` command:

* Assigning deputies to teams
* Allowing multiple deputies to be assigned to the same client
* Automatically generating reports for professional and PA deputies (because that drives the dashboard)
