### PR TITLE
DDPB-2512 - NDR report incorrectly displayed

### DIFF
--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -67,7 +67,8 @@ class ClientController extends RestController
             $client->setDateOfBirth($dob);
         }
 
-        $this->persistAndFlush($client);
+        $this->getEntityManager()->persist($client);
+        $this->getEntityManager()->flush();
 
         return ['id' => $client->getId()];
     }

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -51,7 +51,7 @@ class ClientController extends RestController
         ]);
 
         if ($user && $user->isLayDeputy()) {
-            if (!$client->getNdr() && $user->getNdrEnabled()) {
+            if (array_key_exists('ndr_enabled', $data) && $data['ndr_enabled'] && !$client->getNdr()) {
                 $ndr = new EntityDir\Ndr\Ndr($client);
                 $em->persist($ndr);
             }

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -49,6 +49,13 @@ class ClientController extends RestController
         ]);
 
         if ($this->getUser()->isLayDeputy()) {
+            //add NDR if not added yet
+            // TODO move to listener or service
+            if (!$client->getNdr()) {
+                $ndr = new EntityDir\Ndr\Ndr($client);
+                $this->getEntityManager()->persist($ndr);
+            }
+
             $client->setCourtDate(new \DateTime($data['court_date']));
             $this->hydrateEntityWithArrayData($client, $data, [
                 'case_number' => 'setCaseNumber',
@@ -61,13 +68,6 @@ class ClientController extends RestController
         }
 
         $this->persistAndFlush($client);
-
-        //add NDR if not added yet
-        // TODO move to listener or service
-        if (!$client->getNdr()) {
-            $ndr = new EntityDir\Ndr\Ndr($client);
-            $this->persistAndFlush($ndr);
-        }
 
         return ['id' => $client->getId()];
     }

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -26,6 +26,7 @@ class ClientController extends RestController
         $data = $this->deserializeBodyContent($request);
         /** @var EntityDir\User $user */
         $user = $this->getUser();
+        $em = $this->getEntityManager();
 
         if ($request->getMethod() == 'POST') {
             $client = new EntityDir\Client();
@@ -52,7 +53,7 @@ class ClientController extends RestController
         if ($user && $user->isLayDeputy()) {
             if (!$client->getNdr() && $user->getNdrEnabled()) {
                 $ndr = new EntityDir\Ndr\Ndr($client);
-                $this->getEntityManager()->persist($ndr);
+                $em->persist($ndr);
             }
 
             $client->setCourtDate(new \DateTime($data['court_date']));
@@ -66,7 +67,8 @@ class ClientController extends RestController
             $client->setDateOfBirth($dob);
         }
 
-        $this->persistAndFlush($client);
+        $em->persist($client);
+        $em->flush();
 
         return ['id' => $client->getId()];
     }

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -49,8 +49,6 @@ class ClientController extends RestController
         ]);
 
         if ($this->getUser()->isLayDeputy()) {
-            //add NDR if not added yet
-            // TODO move to listener or service
             if (!$client->getNdr()) {
                 $ndr = new EntityDir\Ndr\Ndr($client);
                 $this->getEntityManager()->persist($ndr);

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -49,11 +49,6 @@ class ClientController extends RestController
         ]);
 
         if ($this->getUser()->isLayDeputy()) {
-            if (!$client->getNdr()) {
-                $ndr = new EntityDir\Ndr\Ndr($client);
-                $this->getEntityManager()->persist($ndr);
-            }
-
             $client->setCourtDate(new \DateTime($data['court_date']));
             $this->hydrateEntityWithArrayData($client, $data, [
                 'case_number' => 'setCaseNumber',
@@ -65,8 +60,7 @@ class ClientController extends RestController
             $client->setDateOfBirth($dob);
         }
 
-        $this->getEntityManager()->persist($client);
-        $this->getEntityManager()->flush();
+        $this->persistAndFlush($client);
 
         return ['id' => $client->getId()];
     }

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -61,7 +61,7 @@ class ClientController extends RestController
             ]);
         }
 
-        if (array_key_exists('date_of_birth', $data['ndrActivated'])) {
+        if (array_key_exists('date_of_birth', $data)) {
             $dob = $data['date_of_birth'] ? new \DateTime($data['date_of_birth']) : null;
             $client->setDateOfBirth($dob);
         }

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -51,7 +51,11 @@ class ClientController extends RestController
         ]);
 
         if ($user && $user->isLayDeputy()) {
-            if (array_key_exists('ndr_enabled', $data) && $data['ndr_enabled'] && !$client->getNdr()) {
+            // We come to this route from either editing or creating a client - need to support
+            // both routes as an NDR needs to exist for the add client route for Lays
+            $ndrRequired = ((array_key_exists('ndr_enabled', $data) && $data['ndr_enabled']) || $user->getNdrEnabled());
+
+            if ($ndrRequired && !$client->getNdr()) {
                 $ndr = new EntityDir\Ndr\Ndr($client);
                 $em->persist($ndr);
             }

--- a/src/AppBundle/Entity/Report/Report.php
+++ b/src/AppBundle/Entity/Report/Report.php
@@ -55,7 +55,6 @@ class Report implements ReportInterface
     const STATUS_NOT_STARTED = 'notStarted';
     const STATUS_READY_TO_SUBMIT = 'readyToSubmit';
     const STATUS_NOT_FINISHED = 'notFinished';
-    const STATUS_CHANGES_NEEDED = 'changesNeeded';
 
     // https://opgtransform.atlassian.net/wiki/spaces/DEPDS/pages/135266255/Report+variations
     const TYPE_103 = '103';

--- a/src/AppBundle/Entity/Report/Report.php
+++ b/src/AppBundle/Entity/Report/Report.php
@@ -55,6 +55,7 @@ class Report implements ReportInterface
     const STATUS_NOT_STARTED = 'notStarted';
     const STATUS_READY_TO_SUBMIT = 'readyToSubmit';
     const STATUS_NOT_FINISHED = 'notFinished';
+    const STATUS_CHANGES_NEEDED = 'changesNeeded';
 
     // https://opgtransform.atlassian.net/wiki/spaces/DEPDS/pages/135266255/Report+variations
     const TYPE_103 = '103';
@@ -1288,5 +1289,4 @@ class Report implements ReportInterface
 
         return $titleTranslationKeys[$this->getType()];
     }
-
 }

--- a/src/AppBundle/Service/ReportStatusService.php
+++ b/src/AppBundle/Service/ReportStatusService.php
@@ -282,7 +282,7 @@ class ReportStatusService
      */
     public function isReadyToSubmit()
     {
-        return count($this->getRemainingSections()) === 0 && $this->report->isDue();
+        return count($this->getRemainingSections()) === 0;
     }
 
     /**
@@ -687,7 +687,7 @@ class ReportStatusService
     public function getSubmitState()
     {
         return [
-            'state'  => $this->isReadyToSubmit()
+            'state'  => $this->isReadyToSubmit() && $this->report->isDue()
                 ? self::STATE_DONE
                 : self::STATE_NOT_STARTED,
             'nOfRecords' => 0,
@@ -723,19 +723,15 @@ class ReportStatusService
      * @JMS\Type("string")
      * @JMS\Groups({"status", "report-status"})
      *
-     * @return string notStarted|readyToSubmit|notFinished|changesNeeded
+     * @return string notStarted|readyToSubmit|notFinished
      */
     public function getStatus()
     {
         if (!$this->hasStarted()) {
-            return Report::STATUS_NOT_STARTED;
+            return 'notStarted';
         }
 
-        if ($this->isUnsubmitted()) {
-            return Report::STATUS_CHANGES_NEEDED;
-        }
-
-        return $this->isReadyToSubmit() ? Report::STATUS_READY_TO_SUBMIT : Report::STATUS_NOT_FINISHED;
+        return $this->report->isDue() && $this->isReadyToSubmit() ? 'readyToSubmit' : 'notFinished';
     }
 
     /**
@@ -747,19 +743,10 @@ class ReportStatusService
     public function getStatusIgnoringDueDate()
     {
         if (!$this->hasStarted()) {
-            return Report::STATUS_NOT_STARTED;
+            return 'notStarted';
         }
 
-        if ($this->isUnsubmitted()) {
-            return Report::STATUS_CHANGES_NEEDED;
-        }
-
-        return count($this->getRemainingSections()) === 0 ? Report::STATUS_READY_TO_SUBMIT : Report::STATUS_NOT_FINISHED;
-    }
-
-    private function isUnsubmitted()
-    {
-        return $this->report->getUnSubmitDate() && !$this->report->getSubmitted();
+        return $this->isReadyToSubmit() ? 'readyToSubmit' : 'notFinished';
     }
 
 }

--- a/src/AppBundle/Service/ReportStatusService.php
+++ b/src/AppBundle/Service/ReportStatusService.php
@@ -282,7 +282,7 @@ class ReportStatusService
      */
     public function isReadyToSubmit()
     {
-        return count($this->getRemainingSections()) === 0;
+        return count($this->getRemainingSections()) === 0 && $this->report->isDue();
     }
 
     /**
@@ -687,7 +687,7 @@ class ReportStatusService
     public function getSubmitState()
     {
         return [
-            'state'  => $this->isReadyToSubmit() && $this->report->isDue()
+            'state'  => $this->isReadyToSubmit()
                 ? self::STATE_DONE
                 : self::STATE_NOT_STARTED,
             'nOfRecords' => 0,
@@ -723,15 +723,19 @@ class ReportStatusService
      * @JMS\Type("string")
      * @JMS\Groups({"status", "report-status"})
      *
-     * @return string notStarted|readyToSubmit|notFinished
+     * @return string notStarted|readyToSubmit|notFinished|changesNeeded
      */
     public function getStatus()
     {
         if (!$this->hasStarted()) {
-            return 'notStarted';
+            return Report::STATUS_NOT_STARTED;
         }
 
-        return $this->report->isDue() && $this->isReadyToSubmit() ? 'readyToSubmit' : 'notFinished';
+        if ($this->isUnsubmitted()) {
+            return Report::STATUS_CHANGES_NEEDED;
+        }
+
+        return $this->isReadyToSubmit() ? Report::STATUS_READY_TO_SUBMIT : Report::STATUS_NOT_FINISHED;
     }
 
     /**
@@ -743,10 +747,19 @@ class ReportStatusService
     public function getStatusIgnoringDueDate()
     {
         if (!$this->hasStarted()) {
-            return 'notStarted';
+            return Report::STATUS_NOT_STARTED;
         }
 
-        return $this->isReadyToSubmit() ? 'readyToSubmit' : 'notFinished';
+        if ($this->isUnsubmitted()) {
+            return Report::STATUS_CHANGES_NEEDED;
+        }
+
+        return count($this->getRemainingSections()) === 0 ? Report::STATUS_READY_TO_SUBMIT : Report::STATUS_NOT_FINISHED;
+    }
+
+    private function isUnsubmitted()
+    {
+        return $this->report->getUnSubmitDate() && !$this->report->getSubmitted();
     }
 
 }

--- a/tests/AppBundle/Controller/AbstractTestController.php
+++ b/tests/AppBundle/Controller/AbstractTestController.php
@@ -49,7 +49,7 @@ abstract class AbstractTestController extends WebTestCase
     }
 
     /**
-     * @return \Fixtures
+     * @return Fixtures
      */
     public static function fixtures()
     {

--- a/tests/AppBundle/Controller/AbstractTestController.php
+++ b/tests/AppBundle/Controller/AbstractTestController.php
@@ -2,14 +2,15 @@
 
 namespace Tests\AppBundle\Controller;
 
-use Fixtures;
+
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Fixtures;
 
 abstract class AbstractTestController extends WebTestCase
 {
     /**
-     * @var \Fixtures
+     * @var Fixtures
      */
     protected static $fixtures;
 

--- a/tests/AppBundle/Controller/CasRecControllerTest.php
+++ b/tests/AppBundle/Controller/CasRecControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\AppBundle\Controller;
 
 use AppBundle\Entity\CasRec;
+use Tests\Fixtures;
 
 class CasRecControllerTest extends AbstractTestController
 {
@@ -121,7 +122,7 @@ class CasRecControllerTest extends AbstractTestController
         $this->assertEndpointNeedsAuth('GET', $url);
         $this->assertEndpointNotAllowedFor('GET', $url, self::$tokenDeputy);
 
-        \Fixtures::deleteReportsData(['casrec']);
+        Fixtures::deleteReportsData(['casrec']);
         $this->fixtures()->persist($this->c1)->flush($this->c1);
 
         // check count

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -159,7 +159,7 @@ class ClientControllerTest extends AbstractTestController
         $return = $this->assertJsonRequest('PUT', $url, [
             'mustSucceed' => true,
             'AuthToken' => self::$tokenDeputy,
-            'data' => ['id' => self::$client1->getId()] + $this->updateDataLay,
+            'data' => ['id' => self::$client1->getId(), 'ndr_enabled' => true] + $this->updateDataLay,
         ]);
         self::fixtures()->clear();
         $client = self::fixtures()->getRepo('Client')->find($return['data']['id']); /* @var $client \AppBundle\Entity\Client */

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\AppBundle\Controller;
 
-use AppBundle\Entity\User;
-
 class ClientControllerTest extends AbstractTestController
 {
     private static $deputy1;

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -123,7 +123,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
     }
 
-    public function testupsertPut_lay_deputy()
+    public function testupsertPutLayDeputy()
     {
         $url = '/client/upsert';
 
@@ -149,7 +149,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
     }
 
-    public function testupsertPut_lay_deputy_ndr_enabled()
+    public function testupsertPutLayDeputyNDREnabled()
     {
         $url = '/client/upsert';
 
@@ -166,7 +166,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertInstanceOf(Ndr::class, $client->getNdr());
     }
 
-    public function testupsertPut_PA()
+    public function testupsertPutPA()
     {
         $url = '/client/upsert';
 

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -119,7 +119,6 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals('Firstname', $client->getFirstname());
         $this->assertCount(1, $client->getUsers());
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
-        $this->assertInstanceOf('AppBundle\Entity\Ndr\Ndr', $client->getNdr());
     }
 
     public function testupsertPut()

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\AppBundle\Controller;
 
+use AppBundle\Entity\Ndr\Ndr;
+
 class ClientControllerTest extends AbstractTestController
 {
     private static $deputy1;
@@ -121,7 +123,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
     }
 
-    public function testupsertPut()
+    public function testupsertPut_lay_deputy()
     {
         $url = '/client/upsert';
 
@@ -145,6 +147,30 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals(null, $client->getDateOfBirth());
         $this->assertEquals('2015-12-31', $client->getCourtDate()->format('Y-m-d'));
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
+    }
+
+    public function testupsertPut_lay_deputy_ndr_enabled()
+    {
+        $url = '/client/upsert';
+
+        $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenAdmin);
+
+        // Lay deputy
+        $return = $this->assertJsonRequest('PUT', $url, [
+            'mustSucceed' => true,
+            'AuthToken' => self::$tokenDeputy,
+            'data' => ['id' => self::$client1->getId()] + $this->updateDataLay,
+        ]);
+        self::fixtures()->clear();
+        $client = self::fixtures()->getRepo('Client')->find($return['data']['id']); /* @var $client \AppBundle\Entity\Client */
+        $this->assertInstanceOf(Ndr::class, $client->getNdr());
+    }
+
+    public function testupsertPut_PA()
+    {
+        $url = '/client/upsert';
+
+        $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenAdmin);
 
         // PA
         $return = $this->assertJsonRequest('PUT', $url, [

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -96,7 +96,7 @@ class ClientControllerTest extends AbstractTestController
         self::fixtures()->clear();
     }
 
-    public function testupsertAuth()
+    public function testUpsertAuth()
     {
         $url = '/client/upsert';
         $this->assertEndpointNeedsAuth('POST', $url);
@@ -106,7 +106,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenAdmin);
     }
 
-    public function testupsertPostLayDeputy()
+    public function testUpsertPostLayDeputy()
     {
         $url = '/client/upsert';
 
@@ -123,7 +123,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
     }
 
-    public function testupsertPutLayDeputy()
+    public function testUpsertPutLayDeputy()
     {
         $url = '/client/upsert';
 
@@ -149,7 +149,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals(self::$deputy1->getId(), $client->getUsers()->first()->getId());
     }
 
-    public function testupsertPutLayDeputyNDREnabled()
+    public function testUpsertPutLayDeputyNDREnabled()
     {
         $url = '/client/upsert';
 
@@ -166,7 +166,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertInstanceOf(Ndr::class, $client->getNdr());
     }
 
-    public function testupsertPutPA()
+    public function testUpsertPutPA()
     {
         $url = '/client/upsert';
 

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -105,7 +105,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEndpointNotAllowedFor('POST', $url, self::$tokenAdmin);
         $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenAdmin);
     }
-// Add to test here to confirm new NDR created
+
     public function testupsertPostLayDeputy()
     {
         $url = '/client/upsert';

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -105,7 +105,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEndpointNotAllowedFor('POST', $url, self::$tokenAdmin);
         $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenAdmin);
     }
-
+// Add to test here to confirm new NDR created
     public function testupsertPostLayDeputy()
     {
         $url = '/client/upsert';

--- a/tests/AppBundle/Controller/ClientControllerTest.php
+++ b/tests/AppBundle/Controller/ClientControllerTest.php
@@ -166,6 +166,7 @@ class ClientControllerTest extends AbstractTestController
         $this->assertEquals('p', $client->getPhone());
         $this->assertEquals('1947-01-31', $client->getDateOfBirth()->format('Y-m-d'));
         $this->assertEquals('pa000001', $client->getCaseNumber()); //assert not changed
+        $this->assertNull($client->getNdr());
     }
 
     public function testfindByIdAuth()

--- a/tests/AppBundle/Controller/PaControllerTest.php
+++ b/tests/AppBundle/Controller/PaControllerTest.php
@@ -3,7 +3,7 @@
 namespace Tests\AppBundle\Controller;
 
 use AppBundle\Service\CsvUploader;
-use Fixtures;
+
 use Tests\AppBundle\Service\OrgServiceTest;
 
 class PaControllerTest extends AbstractTestController

--- a/tests/AppBundle/Controller/SettingControllerTest.php
+++ b/tests/AppBundle/Controller/SettingControllerTest.php
@@ -3,7 +3,7 @@
 namespace Tests\AppBundle\Controller;
 
 use AppBundle\Entity\Setting;
-use Fixtures;
+use Tests\Fixtures;
 
 class SettingControllerTest extends AbstractTestController
 {

--- a/tests/AppBundle/Entity/Repository/ReportRepositoryTest.php
+++ b/tests/AppBundle/Entity/Repository/ReportRepositoryTest.php
@@ -4,11 +4,12 @@ namespace Tests\AppBundle\Entity\Repository;
 
 use AppBundle\Entity\Report\Report;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Fixtures;
 
 class ReportRepositoryTest extends WebTestCase
 {
     /**
-     * @var \Fixtures
+     * @var Fixtures
      */
     private static $fixtures;
     private static $repo;
@@ -19,7 +20,7 @@ class ReportRepositoryTest extends WebTestCase
                                                'debug' => false, ]);
 
         $em = $client->getContainer()->get('em');
-        self::$fixtures = new \Fixtures($em);
+        self::$fixtures = new Fixtures($em);
         self::$fixtures->deleteReportsData();
 
         $em->clear();

--- a/tests/AppBundle/Service/CasrecServiceTest.php
+++ b/tests/AppBundle/Service/CasrecServiceTest.php
@@ -6,11 +6,11 @@ use AppBundle\Entity\CasRec;
 use AppBundle\Service\CasrecService;
 use AppBundle\Service\ReportService;
 use Doctrine\ORM\EntityManager;
-use Fixtures;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Fixtures;
 
 class CasrecServiceTest extends WebTestCase
 {

--- a/tests/AppBundle/Service/OrgServiceTest.php
+++ b/tests/AppBundle/Service/OrgServiceTest.php
@@ -5,11 +5,11 @@ namespace Tests\AppBundle\Service;
 use AppBundle\Entity as EntityDir;
 use AppBundle\Service\OrgService;
 use Doctrine\ORM\EntityManager;
-use Fixtures;
 use Mockery as m;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Tests\Fixtures;
 
 class OrgServiceTest extends WebTestCase
 {

--- a/tests/Fixtures.php
+++ b/tests/Fixtures.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use AppBundle\Entity as EntityDir;
 use Doctrine\ORM\EntityManager;
 


### PR DESCRIPTION
I've moved the NDR creation step to the Lay Deputy specific steps during the upsert action to ensure they are only created for Lay Deputies.

As I was running the unit tests locally I encountered an error while loading the fixtures class so I've namespaced this and updated references as part of this PR.