### PR TITLE
DDBP-2524: Load fixture parameter on demand

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -85,4 +85,4 @@ services:
     AppBundle\DataFixtures\:
         resource: '../../src/AppBundle/DataFixtures'
         tags: ['doctrine.fixture.orm']
-        arguments: ['@security.password_encoder', '%fixtures%']
+        arguments: ['@security.password_encoder']

--- a/src/AppBundle/DataFixtures/UserPasswordFixtures.php
+++ b/src/AppBundle/DataFixtures/UserPasswordFixtures.php
@@ -9,12 +9,10 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 class UserPasswordFixtures extends AbstractDataFixture implements OrderedFixtureInterface
 {
     private $encoder;
-    private $config;
 
-    public function __construct(UserPasswordEncoderInterface $encoder, $config)
+    public function __construct(UserPasswordEncoderInterface $encoder)
     {
         $this->encoder = $encoder;
-        $this->config = $config;
     }
 
     public function doLoad(ObjectManager $manager)
@@ -23,8 +21,10 @@ class UserPasswordFixtures extends AbstractDataFixture implements OrderedFixture
         $userRepository = $manager->getRepository(User::class);
         $users = $userRepository->findAll('');
 
+        $password = $this->container->getParameter('fixtures')['account_password'];
+
         foreach ($users as $user) {
-            $user->setPassword($this->encoder->encodePassword($user, $this->config['account_password']));
+            $user->setPassword($this->encoder->encodePassword($user, $password));
             $manager->persist($user);
         }
 


### PR DESCRIPTION
Removing auto-wiring means that you don't have to define the fixture parameter to start the application. Environments which define the parameter can load fixtures, but those which don't can't.