### PR TITLE
DDPB 2631 NDR creation on enabling

### DIFF
--- a/src/AppBundle/Controller/CoDeputyController.php
+++ b/src/AppBundle/Controller/CoDeputyController.php
@@ -79,7 +79,7 @@ class CoDeputyController extends RestController
             $originalUser = clone $user;
             $user->setEmail($data['email']);
             $userService = $this->get('user_service');
-            $userService->editUser($this->getUser(), $originalUser, $user);
+            $userService->editUser($originalUser, $user);
         }
 
         return [];

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -69,7 +69,7 @@ class UserController extends RestController
         $originalUser = clone $user;
         $data = $this->deserializeBodyContent($request);
         $this->populateUser($user, $data);
-        $userService->editUser($loggedInUser, $originalUser, $user);
+        $userService->editUser($originalUser, $user);
 
         return ['id' => $user->getId()];
     }

--- a/src/AppBundle/Service/UserService.php
+++ b/src/AppBundle/Service/UserService.php
@@ -111,11 +111,11 @@ class UserService
      */
     private function handleNdrStatusUpdate(User $updatedUser)
     {
-        if (!$updatedUser->isLayDeputy()) {
+        $client = $updatedUser->getFirstClient();
+        if (!$updatedUser->isLayDeputy() || !$client instanceof Client) {
             return;
         }
 
-        $client = $updatedUser->getFirstClient();
         if ($updatedUser->getNdrEnabled() && !$this->clientHasExistingNdr($client)) {
             $this->createNdrForClient($client);
         }

--- a/src/AppBundle/Service/UserService.php
+++ b/src/AppBundle/Service/UserService.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\Ndr\Ndr;
 use AppBundle\Entity\Repository\TeamRepository;
 use AppBundle\Entity\Repository\UserRepository;
 use AppBundle\Entity\Team;
@@ -79,9 +80,15 @@ class UserService
             $this->exceptionIfEmailExist($userToEdit->getEmail());
         }
 
-//        if ($loggedInUser->isOrgNamedOrAdmin()) {
-//            $this->orgService->addTeamAndClientsFrom($loggedInUser, $userToAdd, $data);
-//        }
+        if ($userToEdit->isLayDeputy()) {
+            $client = $userToEdit->getFirstClient();
+
+            if ($userToEdit->getNdrEnabled() && null === $client->getNdr()) {
+                $ndr = new Ndr($client);
+                $this->em->persist($ndr);
+                $this->em->flush($ndr, $client);
+            }
+        }
 
         $this->em->flush($userToEdit);
     }

--- a/src/AppBundle/Service/UserService.php
+++ b/src/AppBundle/Service/UserService.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\Client;
 use AppBundle\Entity\Ndr\Ndr;
 use AppBundle\Entity\Repository\TeamRepository;
 use AppBundle\Entity\Repository\UserRepository;
@@ -68,29 +69,31 @@ class UserService
     }
 
     /**
-     * Update a user. Checks that the email is not in use then persists the entity
-     *
-     * @param User $loggedInUser Original user for comparison checks
      * @param User $originalUser Original user for comparison checks
-     * @param User $userToEdit   The user to edit
+     * @param User $updatedUser
+     * @throws \Doctrine\ORM\OptimisticLockException
      */
-    public function editUser(User $loggedInUser, User $originalUser, User $userToEdit)
+    public function editUser(User $originalUser, User $updatedUser)
     {
-        if ($originalUser->getEmail() != $userToEdit->getEmail()) {
-            $this->exceptionIfEmailExist($userToEdit->getEmail());
+        $this
+            ->throwExceptionIfUpdatedEmailExists($originalUser, $updatedUser)
+            ->handleNdrStatusUpdate($updatedUser);
+
+        $this->em->flush();
+    }
+
+    /**
+     * @param User $originalUser
+     * @param User $updatedUser
+     * @return UserService
+     */
+    private function throwExceptionIfUpdatedEmailExists(User $originalUser, User $updatedUser)
+    {
+        if ($originalUser->getEmail() != $updatedUser->getEmail()){
+            $this->exceptionIfEmailExist($updatedUser->getEmail());
         }
 
-        if ($userToEdit->isLayDeputy()) {
-            $client = $userToEdit->getFirstClient();
-
-            if ($userToEdit->getNdrEnabled() && null === $client->getNdr()) {
-                $ndr = new Ndr($client);
-                $this->em->persist($ndr);
-                $this->em->flush($ndr, $client);
-            }
-        }
-
-        $this->em->flush($userToEdit);
+        return $this;
     }
 
     /**
@@ -101,5 +104,38 @@ class UserService
         if ($this->userRepository->findOneBy(['email' => $email])) {
             throw new \RuntimeException("User with email {$email} already exists.", 422);
         }
+    }
+
+    /**
+     * @param User $updatedUser
+     */
+    private function handleNdrStatusUpdate(User $updatedUser)
+    {
+        if (!$updatedUser->isLayDeputy()) {
+            return;
+        }
+
+        $client = $updatedUser->getFirstClient();
+        if ($updatedUser->getNdrEnabled() && !$this->clientHasExistingNdr($client)) {
+            $this->createNdrForClient($client);
+        }
+    }
+
+    /**
+     * @param Client $client
+     * @return bool
+     */
+    private function clientHasExistingNdr(Client $client)
+    {
+        return (null !== $client->getNdr()) ? true : false;
+    }
+
+    /**
+     * @param Client $client
+     */
+    private function createNdrForClient(Client $client)
+    {
+        $ndr = new Ndr($client);
+        $this->em->persist($ndr);
     }
 }


### PR DESCRIPTION
The requirement is to ensure that an NDR gets created when NDR is enabled via the user edit page in admin. We also need to ensure that if it is re-enabled, then it does not create a new NDR. I.e, only create NDR if one does not already exist.

Small refactor of the method:
* Removed unused parameter
* Removed unused code
* Moved exception checking into a method