### PR TITLE
DDPB-2617: Create a test account for a lay deputy with a co deputy

### DIFF
--- a/app/bootstrap.php.cache
+++ b/app/bootstrap.php.cache
@@ -968,20 +968,28 @@ $this->server->set('REQUEST_METHOD', $method);
 }
 public function getMethod()
 {
-if (null === $this->method) {
-$this->method = strtoupper($this->server->get('REQUEST_METHOD','GET'));
-if ('POST'=== $this->method) {
-if ($method = $this->headers->get('X-HTTP-METHOD-OVERRIDE')) {
-$this->method = strtoupper($method);
-} elseif (self::$httpMethodParameterOverride) {
-$method = $this->request->get('_method', $this->query->get('_method','POST'));
-if (\is_string($method)) {
-$this->method = strtoupper($method);
-}
-}
-}
-}
+if (null !== $this->method) {
 return $this->method;
+}
+$this->method = strtoupper($this->server->get('REQUEST_METHOD','GET'));
+if ('POST'!== $this->method) {
+return $this->method;
+}
+$method = $this->headers->get('X-HTTP-METHOD-OVERRIDE');
+if (!$method && self::$httpMethodParameterOverride) {
+$method = $this->request->get('_method', $this->query->get('_method','POST'));
+}
+if (!\is_string($method)) {
+return $this->method;
+}
+$method = strtoupper($method);
+if (\in_array($method, ['GET','HEAD','POST','PUT','DELETE','CONNECT','OPTIONS','PATCH','PURGE','TRACE'], true)) {
+return $this->method = $method;
+}
+if (!preg_match('/^[A-Z]++$/D', $method)) {
+throw new SuspiciousOperationException(sprintf('Invalid method override "%s".', $method));
+}
+return $this->method = $method;
 }
 public function getRealMethod()
 {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6458ebcc40b80a2567cefb02fcf1f892",
+    "content-hash": "768233aa1e7761b5badb43f067f842fe",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2461,7 +2461,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -2760,16 +2760,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.4.24",
+            "version": "v3.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "4783969de06e5b8787b5e3ad2279f6b8aceeb81b"
+                "reference": "1b89e7baec9891c323bbf1ec81af77d901fc60c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/4783969de06e5b8787b5e3ad2279f6b8aceeb81b",
-                "reference": "4783969de06e5b8787b5e3ad2279f6b8aceeb81b",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/1b89e7baec9891c323bbf1ec81af77d901fc60c9",
+                "reference": "1b89e7baec9891c323bbf1ec81af77d901fc60c9",
                 "shasum": ""
             },
             "require": {
@@ -2911,7 +2911,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2019-04-02T13:48:13+00:00"
+            "time": "2019-04-17T15:57:27+00:00"
         },
         {
             "name": "twig/twig",
@@ -3793,6 +3793,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
@@ -4229,5 +4230,8 @@
     "platform": {
         "php": ">=5.5.9"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.5.9"
+    }
 }

--- a/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/src/AppBundle/DataFixtures/UserFixtures.php
@@ -108,6 +108,13 @@ class UserFixtures extends AbstractDataFixture
             'reportVariation' => 'L2',
             'ndr' => true,
         ],
+        [
+            'id' => 'codep',
+            'deputyType' => 'LAY',
+            'reportType' => 'OPG102',
+            'reportVariation' => 'L2',
+            'codeputyEnabled' => true,
+        ],
     ];
 
     public function doLoad(ObjectManager $manager)
@@ -129,6 +136,7 @@ class UserFixtures extends AbstractDataFixture
             ->setActive(true)
             ->setRegistrationDate(new \DateTime())
             ->setNdrEnabled(isset($data['ndr']))
+            ->setCoDeputyClientConfirmed(isset($data['codeputyEnabled']))
             ->setPhoneMain('07911111111111')
             ->setAddress1('Victoria Road')
             ->setAddressPostcode('SW1')

--- a/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/src/AppBundle/DataFixtures/UserFixtures.php
@@ -175,7 +175,6 @@ class UserFixtures extends AbstractDataFixture
             $manager->persist($ndr);
         }
 
-
         // Create report for PROF/PA user 2 years ago
         if ($data['deputyType'] === 'PROF' || $data['deputyType'] === 'PA') {
             $type = CasRec::getTypeBasedOnTypeofRepAndCorref($data['reportType'], $data['reportVariation'], $user->getRoleName());
@@ -187,6 +186,16 @@ class UserFixtures extends AbstractDataFixture
             $report = new Report($client, $type, $startDate, $endDate);
 
             $manager->persist($report);
+        }
+
+        // If codeputy was enabled, add a secondary account
+        if (isset($data['codeputyEnabled'])) {
+            $user2 = clone $user;
+            $user2->setLastname($user2->getLastname() . '-2');
+            $user2->setEmail('behat-' . strtolower($data['deputyType']) .  '-deputy-' . $data['id'] . '-2@publicguardian.gov.uk');
+            $user2->addClient($client);
+
+            $manager->persist($user2);
         }
     }
 


### PR DESCRIPTION
## Purpose
PMs want a test account with access to the "invite a codeputy" flow, so they can easily test clients with multiple deputies.

Fixes [DDPB-2617](https://opgtransform.atlassian.net/browse/DDPB-2617)

## Approach
I've added a new fixture user with the `coDeputyClientConfirmed` property. This gives them access to the new codeputy portal.

## Learning
_N/A_

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
  - Updated [fixture user list](https://opgtransform.atlassian.net/wiki/spaces/DigiDeps/pages/1070334023/Testing)
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A, not present in production
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
  - Symfony upgraded to v3.4.26 to escape 5 security issues present in v3.4.24
- [x] The product team have tested these changes