### PR TITLE
Don't add `CREATE SCHEMA public` commands to down migrations

### DIFF
--- a/ROLLBACK-PROCEDURE.md
+++ b/ROLLBACK-PROCEDURE.md
@@ -24,15 +24,12 @@ From this point onwards, the Jenkins build triggers will push the build through 
 
 ##### Step 2: From the command prompt of the Cloud 9 server `cd` into the `opg-digi-deps-api` directory and run `git pull origin master`.
 
-##### Step 3: Using the integrated IDE, comment out any “CREATE SCHEMA public” commands in the `down()` method of any migration files that will be rolled back
-An unresolved bug in Doctrine inadvertently adds this command in auto generated migrations.
-
-##### Step 4: Run the PHP migration command from the command prompt, using the latest migration that you want to migrate to.
+##### Step 3: Run the PHP migration command from the command prompt, using the latest migration that you want to migrate to.
 For example, if migrations 103 and 102 need rolling back, we want run our migrations back to 101:
 
-`php app/console doctrine:migrations:migrate 101 -n` 
+`php app/console doctrine:migrations:migrate 101 -n`
 
-##### Step 5: Verify status of database and application.
+##### Step 4: Verify status of database and application.
 
 
 

--- a/app/DoctrineMigrations/Version182.php
+++ b/app/DoctrineMigrations/Version182.php
@@ -37,8 +37,6 @@ class Version182 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist_information DROP CONSTRAINT FK_3FB5A813B16D08A7');
         $this->addSql('DROP TABLE checklist');
         $this->addSql('DROP TABLE checklist_information');

--- a/app/DoctrineMigrations/Version183.php
+++ b/app/DoctrineMigrations/Version183.php
@@ -31,8 +31,6 @@ class Version183 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist DROP CONSTRAINT FK_5C696D2F65CF370E');
         $this->addSql('DROP INDEX IDX_5C696D2F65CF370E');
         $this->addSql('ALTER TABLE checklist DROP last_modified_by');

--- a/app/DoctrineMigrations/Version186.php
+++ b/app/DoctrineMigrations/Version186.php
@@ -28,8 +28,6 @@ class Version186 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist DROP satisfied_with_pa_expenses');
     }
 }

--- a/app/DoctrineMigrations/Version193.php
+++ b/app/DoctrineMigrations/Version193.php
@@ -23,7 +23,6 @@ class Version193 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist DROP satisfied_with_health_and_lifestyle');
     }
 }

--- a/app/DoctrineMigrations/Version196.php
+++ b/app/DoctrineMigrations/Version196.php
@@ -27,8 +27,6 @@ class Version196 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist RENAME COLUMN future_significant_decisions TO future_significant_financial_decisions');
     }
 }

--- a/app/DoctrineMigrations/Version198.php
+++ b/app/DoctrineMigrations/Version198.php
@@ -35,8 +35,6 @@ class Version198 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('DROP TABLE prof_deputy_other_cost');
         $this->addSql('CREATE INDEX created_on_idx ON report_submission (created_on)');
 

--- a/app/DoctrineMigrations/Version201.php
+++ b/app/DoctrineMigrations/Version201.php
@@ -30,8 +30,6 @@ class Version201 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('DROP TABLE prof_deputy_interim_cost');
     }
 }

--- a/app/DoctrineMigrations/Version204.php
+++ b/app/DoctrineMigrations/Version204.php
@@ -34,8 +34,6 @@ class Version204 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist DROP deputy_charge_allowed_by_court');
         $this->addSql('ALTER TABLE casrec ADD registration_date TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         $this->addSql('ALTER TABLE casrec ADD last_logged_in TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');

--- a/app/DoctrineMigrations/Version205.php
+++ b/app/DoctrineMigrations/Version205.php
@@ -30,7 +30,6 @@ class Version205 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE report DROP prof_dc_estimate_hc');
         $this->addSql('DROP TABLE prof_deputy_estimate_cost');
     }

--- a/app/DoctrineMigrations/Version206.php
+++ b/app/DoctrineMigrations/Version206.php
@@ -29,8 +29,6 @@ class Version206 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE report DROP prof_dc_estimate_more_info');
         $this->addSql('ALTER TABLE report DROP prof_dc_estimate_more_info_details');
     }

--- a/app/DoctrineMigrations/Version207.php
+++ b/app/DoctrineMigrations/Version207.php
@@ -30,8 +30,6 @@ class Version207 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist DROP payments_match_cost_certificate');
         $this->addSql('ALTER TABLE checklist DROP prof_costs_reasonable_and_proportionate');
         $this->addSql('ALTER TABLE checklist DROP has_deputy_overcharged_from_previous_estimates');

--- a/app/DoctrineMigrations/Version208.php
+++ b/app/DoctrineMigrations/Version208.php
@@ -28,8 +28,6 @@ class Version208 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE report ADD prof_dc_hc_agreed BOOLEAN DEFAULT NULL');
     }
 }

--- a/app/DoctrineMigrations/Version210.php
+++ b/app/DoctrineMigrations/Version210.php
@@ -28,8 +28,6 @@ class Version210 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE checklist DROP next_billing_estimate_satisfactory');
     }
 }

--- a/app/DoctrineMigrations/Version211.php
+++ b/app/DoctrineMigrations/Version211.php
@@ -33,7 +33,6 @@ class Version211 extends AbstractMigration
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE report ADD prof_dc_hc_fixed BOOLEAN DEFAULT NULL');
         $this->addSql('ALTER TABLE report ADD prof_dc_hc_assessed BOOLEAN DEFAULT NULL');
         $this->addSql('ALTER TABLE report DROP prof_dc_how_charged');

--- a/app/DoctrineMigrations/Version212.php
+++ b/app/DoctrineMigrations/Version212.php
@@ -28,8 +28,6 @@ class Version212 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
-
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE document ADD deleted_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
     }
 }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1,33 +1,15 @@
 imports:
     - { resource: services/assemblers.yml }
     - { resource: services/controllers.yml }
+    - { resource: services/event_listeners.yml }
     - { resource: services/rest_handlers.yml }
     - { resource: services/repositories.yml }
     - { resource: services/transformers.yml }
 
 services:
-    kernel.listener.responseConverter:
-        class: AppBundle\EventListener\RestInputOuputFormatter
-        arguments: [ "@jms_serializer", "@logger", ["json"], "json", "%kernel.debug%" ]
-        public: true
-        tags:
-            - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
-            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
     em:
         alias: doctrine.orm.entity_manager
         public: true
-
-    doctrine.listener:
-        class: AppBundle\EventListener\DoctrineListener
-        tags:
-            - { name: doctrine.event_listener, event: prePersist, method: prePersist }
-            - { name: doctrine.event_listener, event: preRemove, method: preRemove }
-
-    fixDefaultSchemaListener:
-        class: AppBundle\EventListener\FixDefaultSchemaListener
-        tags:
-            - { name: doctrine.event_listener, event: postGenerateSchema, method: postGenerateSchema }
 
     opg_digideps.casrec_verification_service:
         class: AppBundle\Service\CasrecVerificationService

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -24,6 +24,11 @@ services:
             - { name: doctrine.event_listener, event: prePersist, method: prePersist }
             - { name: doctrine.event_listener, event: preRemove, method: preRemove }
 
+    fixDefaultSchemaListener:
+        class: AppBundle\EventListener\FixDefaultSchemaListener
+        tags:
+            - { name: doctrine.event_listener, event: postGenerateSchema, method: postGenerateSchema }
+
     opg_digideps.casrec_verification_service:
         class: AppBundle\Service\CasrecVerificationService
         arguments: [ "@em" ]

--- a/app/config/services/event_listeners.yml
+++ b/app/config/services/event_listeners.yml
@@ -1,0 +1,20 @@
+services:
+    kernel.listener.responseConverter:
+        class: AppBundle\EventListener\RestInputOuputFormatter
+        arguments: [ "@jms_serializer", "@logger", ["json"], "json", "%kernel.debug%" ]
+        public: true
+        tags:
+            - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
+            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
+    doctrine.listener:
+        class: AppBundle\EventListener\DoctrineListener
+        tags:
+            - { name: doctrine.event_listener, event: prePersist, method: prePersist }
+            - { name: doctrine.event_listener, event: preRemove, method: preRemove }
+
+    AppBundle\EventListener\FixDefaultSchemaListener:
+        class: AppBundle\EventListener\FixDefaultSchemaListener
+        tags:
+            - { name: doctrine.event_listener, event: postGenerateSchema, method: postGenerateSchema }

--- a/scripts/apiunittest.sh
+++ b/scripts/apiunittest.sh
@@ -9,7 +9,7 @@ export PGUSER=${API_DATABASE_USERNAME:=api}
 
 cd /var/www
 # clear cache
-rm -rf var/*
+rm -rf var/cache/*
 
 rm -f /tmp/dd_stats.csv
 rm -f /tmp/dd_stats.unittest.csv

--- a/src/AppBundle/EventListener/FixDefaultSchemaListener.php
+++ b/src/AppBundle/EventListener/FixDefaultSchemaListener.php
@@ -9,17 +9,15 @@ class FixDefaultSchemaListener implements EventSubscriber
 {
     public function getSubscribedEvents()
     {
-        return array(
-            'postGenerateSchema',
-        );
+        return ['postGenerateSchema'];
     }
 
-    public function postGenerateSchema(GenerateSchemaEventArgs $Args)
+    public function postGenerateSchema(GenerateSchemaEventArgs $args)
     {
-        $Schema = $Args->getSchema();
+        $schema = $args->getSchema();
 
-        if (! $Schema->hasNamespace('public')) {
-            $Schema->createNamespace('public');
+        if (!$schema->hasNamespace('public')) {
+            $schema->createNamespace('public');
         }
     }
 }

--- a/src/AppBundle/EventListener/FixDefaultSchemaListener.php
+++ b/src/AppBundle/EventListener/FixDefaultSchemaListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AppBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+class FixDefaultSchemaListener implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            'postGenerateSchema',
+        );
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $Args)
+    {
+        $Schema = $Args->getSchema();
+
+        if (! $Schema->hasNamespace('public')) {
+            $Schema->createNamespace('public');
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Down migrations generated by Doctrine include a `CREATE SCHEMA public` command. This is erroneous and causes the down migrations to fail (because the public schema already exists).

This is [a known issue](https://github.com/doctrine/dbal/issues/1110) in Doctrine DBAL.

## Approach
I removed the `CREATE SCHEMA public` command from existing migrations, and also introduced a listener which stops them from being added unless necessary (e.g. if we start using multiple schemas).

## Learning
I took the fix from [a comment on the GitHub issue](https://github.com/doctrine/dbal/issues/1110#issuecomment-255765189). This seems to be the accepted solution for now, awaiting Doctrine to fix the issue permanently.

## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [N/A] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
  - False positive on Symfony error fixed in #549
- [N/A] The product team have tested these changes
