### PR TITLE
Expose the environment on the API availability page

### DIFF
--- a/src/AppBundle/Controller/ManageController.php
+++ b/src/AppBundle/Controller/ManageController.php
@@ -20,6 +20,7 @@ class ManageController extends RestController
 
         $data = [
             'healthy' => $dbHealthy,
+            'environment' => $this->get('kernel')->getEnvironment(),
             'errors' => implode("\n", array_filter([$dbError])),
         ];
 


### PR DESCRIPTION
## Purpose
We recently had an issue identifying what configuration environment we'd deployed to a server. This will make it easier to determine that in the future by displaying the environment clearly on the availability page.

Fixes [DDPB-2656](https://opgtransform.atlassian.net/browse/DDPB-2656)

## Approach
I added `$kernel->getEnvironment()` to the response object.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [N/A] The product team have tested these changes
