### PR TITLE
Only create fixture CasRec records for lay deputies

### DIFF
--- a/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/src/AppBundle/DataFixtures/UserFixtures.php
@@ -145,17 +145,19 @@ class UserFixtures extends AbstractDataFixture
 
         $manager->persist($user);
 
-        // Create CasRec record
-        $casRec = new CasRec([
-            'Case' => $data['id'],
-            'Surname' => $data['id'],
-            'Deputy No' => str_replace('-', '', $data['id']),
-            'Dep Surname' => 'User',
-            'Dep Postcode' => 'SW1',
-            'Typeofrep' => $data['reportType'],
-            'Corref' => $data['reportVariation'],
-        ]);
-        $manager->persist($casRec);
+        // Create CasRec record for lay deputies
+        if ($data['deputyType'] === 'LAY') {
+            $casRec = new CasRec([
+                'Case' => $data['id'],
+                'Surname' => $data['id'],
+                'Deputy No' => str_replace('-', '', $data['id']),
+                'Dep Surname' => 'User',
+                'Dep Postcode' => 'SW1',
+                'Typeofrep' => $data['reportType'],
+                'Corref' => $data['reportVariation'],
+            ]);
+            $manager->persist($casRec);
+        }
 
         // Create client
         $client = new Client();


### PR DESCRIPTION
## Purpose
Fixture code currently creates CasRec records for all deputies, but only lay deputies should be included. This causes issues when generating next year's report because it tries to identify a CasRec record to identify the report type.

Fixes an issue identified as part of DDPB-2648.

## Approach
The fixtures now only creates a CasRec entry for lay deputies.

## Learning
The issue was originally caused by not recognising how CasRec works when implementing the new fixtures. This highlights the important of business knowledge in technical changes.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [x] The product team have tested these changes
  - N/A
