### PR TITLE
DDPB-2661: replaces file based session storage in test env with redis

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -3,8 +3,6 @@ imports:
 
 framework:
     test: ~
-    session:
-        storage_id: session.storage.mock_file
     profiler:
         collect: false
 


### PR DESCRIPTION
## Purpose
Prevent Symfony test env from using mock file system in order to cope with running the test suite across multiple api and frontend instances.

Fixes [DDPB-2661](https://opgtransform.atlassian.net/browse/DDPB-2661)

## Approach
Removing the session directive from config_test.yml enables the session storage to fall back to the redis storage due to the fact config_test.yml inherits from config_prod.yml

## Learning
None
## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [N/A] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [ ] The product team have tested these changes
