### PR TITLE
DDBP-2679: Hide Behat controller in production

### DIFF
--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -20,7 +20,7 @@ class BehatController extends RestController
     private function securityChecks()
     {
         if (!$this->container->getParameter('behat_controller_enabled')) {
-            throw $this->createNotFoundException('Behat endpoint disabled, check the behat_controller_enabled parameter');
+            throw $this->createNotFoundException();
         }
     }
 

--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -20,7 +20,7 @@ class BehatController extends RestController
     private function securityChecks()
     {
         if (!$this->container->getParameter('behat_controller_enabled')) {
-            return $this->createNotFoundException('Behat endpoint disabled, check the behat_controller_enabled parameter');
+            throw $this->createNotFoundException('Behat endpoint disabled, check the behat_controller_enabled parameter');
         }
     }
 


### PR DESCRIPTION
## Purpose
The Behat controllers are used for debugging and test automation in non-production environments. However, due to a misconfiguration, they are currently available in production too.

Fixes [DDPB-2679](https://opgtransform.atlassian.net/browse/DDPB-2679)

## Approach
The controller now properly throws an exception rather than returning it (the parent function was ignoring it).

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [ ] The product team have tested these changes
