### PR TITLE
DDPB-2658: Adds lay and non lay specific money out category

### DIFF
--- a/src/AppBundle/Entity/Report/MoneyTransaction.php
+++ b/src/AppBundle/Entity/Report/MoneyTransaction.php
@@ -93,7 +93,8 @@ class MoneyTransaction implements MoneyTransactionInterface
 
         ['deputy-security-bond', false, 'fees', 'out'],
         ['opg-fees', false, 'fees', 'out'],
-        ['professional-fees-eg-solicitor-accountant', true, 'fees', 'out'],
+        ['professional-fees-eg-solicitor-accountant-lay', true, 'fees', 'out'],
+        ['professional-fees-eg-solicitor-accountant-non-lay', true, 'fees', 'out'],
         ['deputy-fees-and-expenses', true, 'fees', 'out'],
 
         ['investment-bonds-purchased', true, 'major-purchases', 'out'],

--- a/src/AppBundle/Entity/Report/MoneyTransaction.php
+++ b/src/AppBundle/Entity/Report/MoneyTransaction.php
@@ -93,7 +93,7 @@ class MoneyTransaction implements MoneyTransactionInterface
 
         ['deputy-security-bond', false, 'fees', 'out'],
         ['opg-fees', false, 'fees', 'out'],
-        ['professional-fees-eg-solicitor-accountant-lay', true, 'fees', 'out'],
+        ['professional-fees-eg-solicitor-accountant', true, 'fees', 'out'],
         ['professional-fees-eg-solicitor-accountant-non-lay', true, 'fees', 'out'],
         ['deputy-fees-and-expenses', true, 'fees', 'out'],
 


### PR DESCRIPTION
## Purpose
To enable the displaying of category text based on the user role. 

Fixes [DDPB-2658](https://opgtransform.atlassian.net/browse/DDPB-2658)

## Approach
The client side now has two category types, one for lay and one for non lay. To ensure the new types are returned in API calls, we need to add the new type strings to MoneyTransaction on the API side.

## Learning


## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [ ] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [ ] The product team have tested these changes
