### PR TITLE
DDPB-2637: Tidy up API config files

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -1,19 +1,6 @@
 imports:
-    - { resource: config.yml }
+    - { resource: config_prod.yml }
 
-framework:
-    router:
-        resource: "%kernel.root_dir%/config/routing_dev.yml"
-        strict_requirements: true
-    profiler: { only_exceptions: false }
-
-monolog:
-   handlers:
-       main:
-           formatter: line_formatter
-           
 jms_serializer:
     metadata:
-        cache: none
-        cache: file
-        debug: true           
+        debug: true

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: config_dev.yml }
+    - { resource: config_prod.yml }
 
 framework:
     test: ~
@@ -8,8 +8,8 @@ framework:
 
 doctrine:
     dbal:
-        dbname:   digideps_unit_test
-        
+        dbname: digideps_unit_test
+
 services:
     attemptsInTimeChecker:
         class:  AppBundle\Service\BruteForce\AttemptsInTimeChecker
@@ -35,13 +35,8 @@ monolog:
            type: stream
            path: "%log_path%"
            level: warning
-           
+           formatter: line_formatter
+
 jms_serializer:
     metadata:
-        cache: none
-        cache: file
         debug: true
-        
-parameters:
-    fixtures:
-        account_password: Abcd1234

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -1,6 +1,0 @@
-_main:
-    resource: routing.yml
-
-# AcmeDemoBundle routes (to be removed)
-#_acme_demo:
-#    resource: "@AcmeDemoBundle/Resources/config/routing.yml"


### PR DESCRIPTION
## Purpose
The API config files have both of duplication and unnecessary rules. This obscures the actual configuration of the environment, and makes future config changes more risky.

Fixes [DDPB-2637](https://opgtransform.atlassian.net/browse/DDPB-2637)

## Approach
I switched both `config_dev` and `config_test` to build off of `config_prod` so that any changes to the production configuration also affect dev and test ones.

I removed any duplication, and any rules which were unnecessary (e.g. the extra routing rules didn't do anything and the extra profiler rules have no effect because the profiler is disabled).

## Learning
Nothing particularly interesting.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [x] The product team have tested these changes
  - N/A, no outward facing changes