### PR TITLE
DDPB-2742: PA client overview page inaccessible after expenses added

### DIFF
--- a/src/AppBundle/Entity/Report/Traits/FeeExpensesTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/FeeExpensesTrait.php
@@ -261,7 +261,7 @@ trait FeeExpensesTrait
 
         $feeComplete = $countValidFees || !empty($this->getReasonForNoFees());
         $expenseComplete = $this->getPaidForAnything() === 'no'
-            || ($this->getPaidForAnything() === 'yes' && count($countExpenses));
+            || ($this->getPaidForAnything() === 'yes' && $countExpenses);
 
         return $feeComplete && $expenseComplete;
     }


### PR DESCRIPTION
## Purpose
If a PA deputy adds a expense to a report, then the report overview page crashes.

This is due to a bug with `FeeExpensesTrait`, which has a double-count in it (effectively `count(count($expenses))`). In PHP5 this was skipped over, but PHP7 throws a fatal error when asked to count an integer.

Fixes [DDPB-2742](https://opgtransform.atlassian.net/browse/DDPB-2742)

## Approach
I removed the second `count` function.

## Learning
We were already aware of this problem, but weren't able to identify every scenario it occurred in. Fortunately it was easy to identify from errors logs in CloudWatch.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [ ] The product team have tested these changes
