### PR TITLE
Ddpb 2624 fixture users in tests

### DIFF
--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -49,7 +49,14 @@ class BehatController extends RestController
                 throw new \RuntimeException('Cannot re-assign client to new deputy: ' . $data['new_deputy_email'] .
                     ' User not found');
             }
-            $client->setUsers(new ArrayCollection());
+            $existingClient = $newDeputy->getFirstClient();
+            $newDeputy->removeClient($existingClient);
+            $existingDeputies = $client->getUsers();
+            foreach ($existingDeputies as $existingDeputy)
+            {
+                $client->removeUser($existingDeputy);
+            }
+
             $client->addUser($newDeputy);
             $this->get('em')->flush($client);
         }

--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Client;
 use AppBundle\Entity\Report\Report;
 use AppBundle\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,6 +41,17 @@ class BehatController extends RestController
             $report = $client->getCurrentReport();
             $report->setType($data['current_report_type']);
             $this->get('em')->flush($report);
+        }
+
+        if (array_key_exists('new_deputy_email', $data)) {
+            $newDeputy = $this->findEntityBy(User::class, ['email' => $data['new_deputy_email']]);
+            if (!$newDeputy instanceof User) {
+                throw new \RuntimeException('Cannot re-assign client to new deputy: ' . $data['new_deputy_email'] .
+                    ' User not found');
+            }
+            $client->setUsers(new ArrayCollection());
+            $client->addUser($newDeputy);
+            $this->get('em')->flush($client);
         }
     }
 

--- a/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/src/AppBundle/DataFixtures/UserFixtures.php
@@ -12,16 +12,16 @@ class UserFixtures extends AbstractDataFixture
 {
     private $userData = [
         [
-            'id' => '103',
-            'deputyType' => 'LAY',
-            'reportType' => 'OPG103',
-            'reportVariation' => 'L3',
-        ],
-        [
             'id' => '102',
             'deputyType' => 'LAY',
             'reportType' => 'OPG102',
             'reportVariation' => 'L2',
+        ],
+        [
+            'id' => '103',
+            'deputyType' => 'LAY',
+            'reportType' => 'OPG103',
+            'reportVariation' => 'L3',
         ],
         [
             'id' => '104',

--- a/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/src/AppBundle/DataFixtures/UserFixtures.php
@@ -164,7 +164,7 @@ class UserFixtures extends AbstractDataFixture
         $client
             ->setCaseNumber($data['id'])
             ->setFirstname('John')
-            ->setLastname($data['id'])
+            ->setLastname($data['id'] . '-client')
             ->setPhone('022222222222222')
             ->setAddress('Victoria road')
             ->setCourtDate(\DateTime::createFromFormat('d/m/Y', '01/11/2017'));


### PR DESCRIPTION
## Purpose
Reduce the dependancy on behat-user that is created by a test. This in turn reduces the interdependency of tests requiring other tests to run.
Fixes [DDPB-2624]

## Approach
Ive used the appropriate fixture users to replace the instances of behat-user with those required for the report being tested. So behat-lay-deputy-102 for 102 report, 103 for 103 report etc. The behat user is still used for ttesting CASREC and creating users and cross checks.

## Learning
As we were using a different deputy, then the client also changed so many tests needed to be updated with content associated with the new client.
When switching between different report types, we simply change the report type as needed, to avoid retesting sections already completed. This had a knock on effect in that when changing report type, I updated the deputy logged on. Which in turn changed the client yet again. To get around this I updated the PUT client/edit api method to accept a new deputy email address. This allows us to update the deputy for the same client without having to insert user ids in the test. It then gives rise to a random error caused by the new deputy having two clients (the new one and the one it originally had). So the code also has to remove the old one.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
- [n/a] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [ ] The product team have tested these changes
