### PR TITLE
DDPB-2751 Ensured email address is lowercase before requesting new token

### DIFF
--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -312,7 +312,7 @@ class UserController extends RestController
         }
 
         /** @var EntityDir\User $user */
-        $user = $this->findEntityBy(EntityDir\User::class, ['email' => $email]);
+        $user = $this->findEntityBy(EntityDir\User::class, ['email' => strtolower($email)]);
 
         $hasAdminSecret = $this->getAuthService()->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request);
 


### PR DESCRIPTION
## Purpose
Ensure password reset works with both upper and lower case input.

Fixes [DDPB-2751](https://opgtransform.atlassian.net/browse/DDPB-2751)

## Approach
strtolower email in User entity when requesting email, in case any database entries are in upper case, and changed api call to reset token with lower case email

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [ ] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [ ] The product team have tested these changes
