### PR TITLE
Add technical debt document

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,7 @@
+# Technical debt
+
+A log of technical debt we're aware of and have accepted. These aren't "problems", but we might like to address them in the future if we have suitable time and resource, if related work gives an opportunity, or if they become more pressing.
+
+- There are several files and folders we don't use any more which can be safely removed
+- We should use environment variables as feature switches, rather than having separate config files/envtrypoints for each environment
+- We should use `bin/phpunit` when running tests (instead of `vendor/phpunit/phpunit/phpunit`)

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -11,7 +11,7 @@ _Any tips and tricks, blog posts or tools which helped you. Plus anything notabl
 
 ## Checklist
 - [ ] I have performed a self-review of my own code
-- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
+- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
 - [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
 - [ ] I have successfully built my branch to a feature environment
 - [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)


### PR DESCRIPTION
## Purpose
We want to record known technical debt in DigiDeps.

## Approach
I created a document to record tech debt (and [another in client](https://github.com/ministryofjustice/opg-digi-deps-client/pull/1288)). I also added it as a documentation option in our PR template.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
