### PR TITLE
DDPB-2797: Remove `/behat/client` route

### DIFF
--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -26,43 +26,6 @@ class BehatController extends RestController
     }
 
     /**
-     * @Route("/client/{caseNumber}")
-     * @Method({"PUT"})
-     */
-    public function clientEditAction(Request $request, $caseNumber)
-    {
-        $this->securityChecks();
-
-        /* @var $client Client */
-        $client = $this->findEntityBy(Client::class, ['caseNumber' => $caseNumber]);
-
-        $data = $this->deserializeBodyContent($request);
-        if (array_key_exists('current_report_type', $data)) {
-            $report = $client->getCurrentReport();
-            $report->setType($data['current_report_type']);
-            $this->get('em')->flush($report);
-        }
-
-        if (array_key_exists('new_deputy_email', $data)) {
-            $newDeputy = $this->findEntityBy(User::class, ['email' => $data['new_deputy_email']]);
-            if (!$newDeputy instanceof User) {
-                throw new \RuntimeException('Cannot re-assign client to new deputy: ' . $data['new_deputy_email'] .
-                    ' User not found');
-            }
-            $existingClient = $newDeputy->getFirstClient();
-            $newDeputy->removeClient($existingClient);
-            $existingDeputies = $client->getUsers();
-            foreach ($existingDeputies as $existingDeputy)
-            {
-                $client->removeUser($existingDeputy);
-            }
-
-            $client->addUser($newDeputy);
-            $this->get('em')->flush($client);
-        }
-    }
-
-    /**
      * @Route("/report/{reportId}")
      * @Method({"PUT"})
      */


### PR DESCRIPTION
## Purpose
Due to our client side changes, we no longer need the `/behat/client` route.

Fixes [DDPB-2797](https://opgtransform.atlassian.net/browse/DDPB-2797)

## Approach
I removed the action.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [x] The product team have tested these changes
  - N/A
