### PR TITLE
DDPB-2714: Flush all changes after adding asset

### DIFF
--- a/api/src/AppBundle/Controller/Ndr/AssetController.php
+++ b/api/src/AppBundle/Controller/Ndr/AssetController.php
@@ -69,7 +69,9 @@ class AssetController extends RestController
 
         $this->updateEntityWithData($asset, $data);
         $ndr->setNoAssetToAdd(false);
-        $this->persistAndFlush($asset);
+
+        $this->getEntityManager()->persist($asset);
+        $this->getEntityManager()->flush();
 
         return ['id' => $asset->getId()];
     }


### PR DESCRIPTION
## Purpose
Testing of DDPB-2714 identified a bug where the assets summary page always said there were no assets, even after you've added one.

This is because the code to add an asset was only persisting the new asset, not other changes. So, although it set `no_asset_to_add` to false, this change wasn't being saved.

Fixes [DDPB-2714](https://opgtransform.atlassian.net/browse/DDPB-2714)

## Approach
I altered the persist/flush process to ensure changes to all changed entities are saved.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm api sh scripts/apiunittest.sh`)
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)
- [x] The product team have tested these changes
  - N/A
